### PR TITLE
[jsk_pr2_startup] Speak warning message when battery voltage is low

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_warning/battery_warning.py
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_warning/battery_warning.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 # Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
 
+from __future__ import division
+
 import actionlib
 from collections import defaultdict
 import os.path as osp
@@ -29,6 +31,8 @@ class BatteryWarning(object):
         self.monitor_rate = rospy.get_param("~monitor_rate", 4)
         self.warning_temp = rospy.get_param("~warning_temperature", 42.0)
         self.min_capacity = rospy.get_param("~min_capacity", 800)
+        self.warning_voltage = rospy.get_param("~warning_voltage", 14.0)
+        self.critical_voltage = rospy.get_param("~critical_voltage", 13.7)
         self.warn_repeat_rate = rospy.get_param("~warn_repeat_rate", 180)
         self.log_rate = rospy.get_param("~log_rate", 10)
         self.log_path = rospy.get_param("~log_path", None)
@@ -118,6 +122,20 @@ class BatteryWarning(object):
             if 15 < min_perc < 30:
                 self.speak("充電してください。")
             elif 0 <= min_perc < 15:
+                self.speak("もう限界です！")
+        except KeyError:
+            pass
+        except ValueError:
+            pass
+
+        try:
+            voltage = df["Voltage (mV)"].astype(int).min() / 1000
+            if (prev_plugged_in and plugged_in) or \
+               voltage < self.warning_voltage:
+                self.speak("電池電圧%.1fボルトです。" % voltage)
+            if self.critical_voltage < voltage < self.warning_voltage:
+                self.speak("充電してください。")
+            elif voltage <= self.critical_voltage:
                 self.speak("もう限界です！")
         except KeyError:
             pass


### PR DESCRIPTION
PR2 will speak warning message when battery voltage is low because it might cause sudden shutdown.
The "voltage" is minimum value of voltage of all batteries.

The voltage of batteries on PR1040 measured on 2019/5/17 18:04:51, only a few seconds before shutdown, was below.
```
battery 0.0: 15921mV
battery 0.1: 15919mV
battery 0.2: 15925mV
battery 0.3: 15946mV
```
```
battery 1.0: 15875mV
battery 1.1: 15879mV
battery 1.2: 15889mV
battery 1.3: 15904mV
```
```
battery 2.0: 13394mV
battery 2.1: 13404mV
battery 2.2: 13447mV
battery 2.3: 13408mV
```
```
battery 3.0: 15931mV
battery 3.1: 15937mV
battery 3.2: 15941mV
battery 3.3: 15988mV
```

In this case the minimum value is 13394mV ≒ 13.4V.
I set `~warning_voltage` to `14.0V` and `~critical_voltage` to `13.7V` as a default value.
