### PR TITLE
[jsk_fetch_startup] Use upstart log output in log-wifi-link.sh

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/log-wifi-link.sh
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/log-wifi-link.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 IFACE=wlan0
-OUTPATH=/var/log/wifi.log
 INTERVAL=10
 
 wifi_status(){
@@ -14,12 +13,7 @@ wifi_status(){
     echo "$(date -Iseconds),$ssid,$freq,$signal,$level,$noise,$bitrate"
 }
 
-OUTDIR=$(dirname $OUTPATH)
-if [ ! -d $OUTDIR ]; then
-    mkdir -p $OUTDIR
-fi
-
 while true; do
-    wifi_status >> $OUTPATH
+    wifi_status >&1
     sleep $INTERVAL
 done


### PR DESCRIPTION
Currently `/var/log/wifi.log` is (516MB) very large because all the logs so far were stored in `/var/log/wifi.log`.

Now that we can use this script in upstart, I think it's better to save wifi logs in `/var/log/upstart/jsk-log-wifi.log`.

I'd like to find out the difference in fetch's wifi speed when I change the antenna.