### PR TITLE
[move_slow_and_clear] Recover from move_slow_and_clear with TrajectororyPlannerROS

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall
@@ -81,3 +81,7 @@
     local-name: tork-a/visualization_rwt
     uri: https://github.com/tork-a/visualization_rwt.git
     version: knorth55/fetch15
+- git:
+    local-name: ros-planning/navigation
+    uri: https://github.com/ros-planning/navigation.git
+    version: 708yamaguchi/add-max-vel-name-param-indigo

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -297,6 +297,9 @@
         limited_trans_speed: 0.2
         limited_rot_speed: 0.52
         limited_distance: 0.3
+        planner_namespace: TrajectoryPlannerROS
+        max_trans_param_name: max_vel_x
+        max_rot_param_name: max_vel_theta
       max_planning_retries: 2
     </rosparam>
   </group>


### PR DESCRIPTION
Currently, I use 708yamaguchi/navigation add-max-vel-name-param-indigo branch, forked from ros-planning/navigation

https://github.com/ros-planning/navigation/pull/1039