### PR TITLE
add audio play to rosbag_play.launch

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/rosbag_play.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/rosbag_play.launch
@@ -16,7 +16,7 @@
   <arg name="QUAT_RGB_IMAGE" value="/head_camera/rgb/quater/throttled/image_rect_color" />
   <arg name="DEPTH_CAMERA_INFO" value="/head_camera/depth_registered/throttled/camera_info" />
   <arg name="DEPTH_IMAGE" value="/head_camera/depth_registered/throttled/image_rect" />
-  
+
   <param name="use_sim_time" value="true" />
   <param name="robot_description" textfile="$(find fetch_description)/robots/fetch.urdf" />
 

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/rosbag_play.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/rosbag_play.launch
@@ -90,7 +90,7 @@
 
   <!-- audio play -->
   <node pkg="audio_play" type="audio_play" name="audio_play" if="$(arg audio_play)" output="screen">
-	    <param name="device" value="$(arg audio_device)" />
+        <param name="device" value="$(arg audio_device)" />
         <param name="dst" value="alsasink"/>
         <param name="do_timestamp" value="false"/>
         <param name="format" value="wave"/>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/rosbag_play.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/rosbag_play.launch
@@ -91,7 +91,7 @@
   <node pkg="audio_play" type="audio_play" name="audio_play" if="$(arg play_audio)" output="screen">
         <param name="dst" value="alsasink"/>
         <param name="do_timestamp" value="false"/>
-        <param name="format" value="mp3"/>
+        <param name="format" value="wave"/>
         <param name="channels" value="1"/>
         <param name="sample_rate" value="16000"/>
         <param name="sample_format" value="S16LE"/>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/rosbag_play.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/rosbag_play.launch
@@ -7,6 +7,7 @@
   <arg name="gui" default="false" />
   <arg name="loop_flag" value="--loop" if="$(arg loop)" />
   <arg name="loop_flag" value="" unless="$(arg loop)" />
+  <arg name="play_audio" default="false" />
 
   <arg name="RGB_CAMERA_INFO" value="/head_camera/rgb/throttled/camera_info" />
   <arg name="RGB_IMAGE" value="/head_camera/rgb/throttled/image_rect_color" />
@@ -84,6 +85,16 @@
         output="screen" >
       <param name="~file" value="$(arg rosbag)" />
       <param name="~topicname" value="/map" />
+  </node>
+
+  <!-- audio play -->
+  <node pkg="audio_play" type="audio_play" name="audio_play" if="$(arg play_audio)" output="screen">
+        <param name="dst" value="alsasink"/>
+        <param name="do_timestamp" value="false"/>
+        <param name="format" value="mp3"/>
+        <param name="channels" value="1"/>
+        <param name="sample_rate" value="16000"/>
+        <param name="sample_format" value="S16LE"/>
   </node>
 
   <!-- rosbag player -->

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/rosbag_play.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/rosbag_play.launch
@@ -7,7 +7,8 @@
   <arg name="gui" default="false" />
   <arg name="loop_flag" value="--loop" if="$(arg loop)" />
   <arg name="loop_flag" value="" unless="$(arg loop)" />
-  <arg name="play_audio" default="false" />
+  <arg name="audio_play" default="false" />
+  <arg name="audio_device" default="" />
 
   <arg name="RGB_CAMERA_INFO" value="/head_camera/rgb/throttled/camera_info" />
   <arg name="RGB_IMAGE" value="/head_camera/rgb/throttled/image_rect_color" />
@@ -15,7 +16,7 @@
   <arg name="QUAT_RGB_IMAGE" value="/head_camera/rgb/quater/throttled/image_rect_color" />
   <arg name="DEPTH_CAMERA_INFO" value="/head_camera/depth_registered/throttled/camera_info" />
   <arg name="DEPTH_IMAGE" value="/head_camera/depth_registered/throttled/image_rect" />
-
+  
   <param name="use_sim_time" value="true" />
   <param name="robot_description" textfile="$(find fetch_description)/robots/fetch.urdf" />
 
@@ -88,7 +89,8 @@
   </node>
 
   <!-- audio play -->
-  <node pkg="audio_play" type="audio_play" name="audio_play" if="$(arg play_audio)" output="screen">
+  <node pkg="audio_play" type="audio_play" name="audio_play" if="$(arg audio_play)" output="screen">
+	    <param name="device" value="$(arg audio_device)" />
         <param name="dst" value="alsasink"/>
         <param name="do_timestamp" value="false"/>
         <param name="format" value="wave"/>


### PR DESCRIPTION
To play `/audio` topic by launching `rosbag_play.launch`, I add the node `audio_play` in the launch file.

However the sound is not played on my computer. I recorded the rosbag by using `rosbag_record.launch` and confirmed the rosbag file publishes `/audio`. 
I executed `roslaunch audio_capture capture.launch` `roslaunch audio_play play.launch`, and they play sound correctly, so I think there are no problems with audio_play package.

====
- `rosversion audio_play` shows `0.3.8`
- `roslaunch jsk_fetch_startup rosbag_play.launch rosbag:=`rospack find jsk_2020_09_fetch_goto_office`/rosbag/20201014_office_1.bag gui:=true play_audio:=true` shows
```
... logging to /home/tork/.ros/log/072cbfd8-11d6-11eb-a323-c0b883e85b16/roslaunch-oem-ThinkPad-T490-1650.log
Checking log directory for disk usage. This may take a while.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

started roslaunch server http://oem-ThinkPad-T490:36071/

SUMMARY
========

PARAMETERS
 * /audio_play/channels: 1
 * /audio_play/do_timestamp: False
 * /audio_play/dst: alsasink
 * /audio_play/format: mp3
 * /audio_play/sample_format: S16LE
 * /audio_play/sample_rate: 16000
 * /latched_topic_republisher_map/file: /home/tork/resear...
 * /latched_topic_republisher_map/topicname: /map
 * /latched_topic_republisher_tf_static/file: /home/tork/resear...
 * /latched_topic_republisher_tf_static/topicname: /tf_static
 * /point_cloud_xyzrgb/queue_size: 100
 * /resize_cloud/step_x: 4
 * /resize_cloud/step_y: 4
 * /resize_rgb/scale_height: 0.25
 * /resize_rgb/scale_width: 0.25
 * /robot_description: <robot name="fetc...
 * /rosdistro: melodic
 * /rosversion: 1.14.9
 * /use_sim_time: True

NODES
  /
    audio_play (audio_play/audio_play)
    depth_decompress (image_transport/republish)
    depth_image_relay (topic_tools/relay)
    depth_info_relay (topic_tools/relay)
    latched_topic_republisher_map (jsk_fetch_startup/latched_topic_republisher.py)
    latched_topic_republisher_tf_static (jsk_fetch_startup/latched_topic_republisher.py)
    point_cloud_xyzrgb (nodelet/nodelet)
    points_relay (topic_tools/relay)
    quat_points_relay (topic_tools/relay)
    quat_rgb_image_relay (topic_tools/relay)
    quat_rgb_info_relay (topic_tools/relay)
    resize_cloud (nodelet/nodelet)
    resize_rgb (nodelet/nodelet)
    rgb_decompress (image_transport/republish)
    rgb_image_relay (topic_tools/relay)
    rgb_info_relay (topic_tools/relay)
    rosbag_play (rosbag/play)
    rosbag_play_nodelet_manager (nodelet/nodelet)
    rviz_oem_ThinkPad_T490_1650_6572351251912843014 (rviz/rviz)

auto-starting new master
process[master]: started with pid [1660]
ROS_MASTER_URI=http://localhost:11311

setting /run_id to 072cbfd8-11d6-11eb-a323-c0b883e85b16
process[rosout-1]: started with pid [1671]
started core service [/rosout]
process[rosbag_play_nodelet_manager-2]: started with pid [1677]
process[rgb_decompress-3]: started with pid [1679]
process[depth_decompress-4]: started with pid [1680]
process[point_cloud_xyzrgb-5]: started with pid [1682]
process[resize_rgb-6]: started with pid [1687]
process[resize_cloud-7]: started with pid [1694]
[ INFO] [1603089651.720384377]: Loading nodelet /point_cloud_xyzrgb of type depth_image_proc/point_cloud_xyzrgb to manager rosbag_play_nodelet_manager with the following remappings:
[ INFO] [1603089651.721091424]: /depth_registered/image_rect -> /head_camera/depth_registered/throttled/image_rect
[ INFO] [1603089651.721166545]: /depth_registered/points -> /head_camera/depth_registered/throttled/points
[ INFO] [1603089651.721193720]: /rgb/camera_info -> /head_camera/rgb/throttled/camera_info
[ INFO] [1603089651.721219284]: /rgb/image_rect_color -> /head_camera/rgb/throttled/image_rect_color
[ INFO] [1603089651.722329541]: waitForService: Service [/rosbag_play_nodelet_manager/load_nodelet] has not been advertised, waiting...
process[rgb_image_relay-8]: started with pid [1702]
[ INFO] [1603089651.732069238]: Loading nodelet /resize_rgb of type image_proc/resize to manager rosbag_play_nodelet_manager with the following remappings:
[ INFO] [1603089651.732749839]: /camera_info -> /head_camera/rgb/throttled/camera_info
[ INFO] [1603089651.732773726]: /image -> /head_camera/rgb/throttled/image_rect_color
[ INFO] [1603089651.732793035]: /resize_rgb/camera_info -> /head_camera/rgb/quater/throttled/camera_info
[ INFO] [1603089651.732806146]: /resize_rgb/image -> /head_camera/rgb/quater/throttled/image_rect_color
[ INFO] [1603089651.733787163]: waitForService: Service [/rosbag_play_nodelet_manager/load_nodelet] has not been advertised, waiting...
process[rgb_info_relay-9]: started with pid [1709]
[ INFO] [1603089651.738118162]: Loading nodelet /resize_cloud of type jsk_pcl/ResizePointsPublisher to manager rosbag_play_nodelet_manager with the following remappings:
[ INFO] [1603089651.738791959]: /resize_cloud/input -> /head_camera/depth_registered/throttled/points
[ INFO] [1603089651.738810779]: /resize_cloud/output -> /head_camera/depth_registered/quater/throttled/points
[ INFO] [1603089651.739694287]: waitForService: Service [/rosbag_play_nodelet_manager/load_nodelet] has not been advertised, waiting...
process[quat_rgb_image_relay-10]: started with pid [1716]
process[quat_rgb_info_relay-11]: started with pid [1723]
process[depth_image_relay-12]: started with pid [1733]
[ INFO] [1603089651.771661973]: Initializing nodelet with 8 worker threads.
process[depth_info_relay-13]: started with pid [1742]
[ INFO] [1603089651.780119584]: waitForService: Service [/rosbag_play_nodelet_manager/load_nodelet] is now available.
process[points_relay-14]: started with pid [1765]
[ INFO] [1603089651.787465881]: waitForService: Service [/rosbag_play_nodelet_manager/load_nodelet] is now available.
[ INFO] [1603089651.790521090]: waitForService: Service [/rosbag_play_nodelet_manager/load_nodelet] is now available.
process[quat_points_relay-15]: started with pid [1780]
process[latched_topic_republisher_tf_static-16]: started with pid [1787]
process[latched_topic_republisher_map-17]: started with pid [1793]
process[audio_play-18]: started with pid [1795]
process[rosbag_play-19]: started with pid [1796]
process[rviz_oem_ThinkPad_T490_1650_6572351251912843014-20]: started with pid [1798]
[ INFO] [1603089651.878359560]: Opening /home/tork/research_ws/src/jsk_demos/jsk_2020_09_fetch_goto_office/rosbag/20201014_office_1.bag

Waiting 0.2 seconds after advertising topics...[ERROR] [1603089652.435257592]: Failed to load nodelet [/resize_cloud] of type [jsk_pcl/ResizePointsPublisher] even after refreshing the cache: Failed to load library /home/tork/research_ws/devel/lib/libjsk_pcl_ros.so. Make sure that you are calling the PLUGINLIB_EXPORT_CLASS macro in the library code, and that names are consistent between this macro and your XML. Error string: Could not load library (Poco exception = /home/tork/research_ws/devel/lib/libjsk_pcl_ros.so: undefined symbol: _ZN15jsk_topic_tools22ConnectionBasedNodelet11warnNoRemapESt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EE)
[ERROR] [1603089652.435306103]: The error before refreshing the cache was: Failed to load library /home/tork/research_ws/devel/lib/libjsk_pcl_ros.so. Make sure that you are calling the PLUGINLIB_EXPORT_CLASS macro in the library code, and that names are consistent between this macro and your XML. Error string: Could not load library (Poco exception = /home/tork/research_ws/devel/lib/libjsk_pcl_ros.so: undefined symbol: _ZN15jsk_topic_tools22ConnectionBasedNodelet11warnNoRemapESt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EE)
[FATAL] [1603089652.435428740]: Failed to load nodelet '/resize_cloud` of type `jsk_pcl/ResizePointsPublisher` to manager `rosbag_play_nodelet_manager'
 done.

Hit space to toggle paused, or 's' to step.
[resize_cloud-7] process has died [pid 1694, exit code 255, cmd /opt/ros/melodic/lib/nodelet/nodelet load jsk_pcl/ResizePointsPublisher rosbag_play_nodelet_manager ~input:=/head_camera/depth_registered/throttled/points ~output:=/head_camera/depth_registered/quater/throttled/points __name:=resize_cloud __log:=/home/tork/.ros/log/072cbfd8-11d6-11eb-a323-c0b883e85b16/resize_cloud-7.log].
log file: /home/tork/.ros/log/072cbfd8-11d6-11eb-a323-c0b883e85b16/resize_cloud-7*.log
[ WARN] [1603089656.307553230, 1602648829.779942586]: Messages of type 1 arrived out of order (will print only once)
[WARN] [1603089667.018394, 1602648840.490904]: Fail to republish topic: /tf_static        
[WARN] [1603089667.020011, 1602648840.490904]: There is no topic /tf_static in /home/tork/research_ws/src/jsk_demos/jsk_2020_09_fetch_goto_office/rosbag/20201014_office_1.bag
[INFO] [1603089684.612026, 1602648858.034254]: Republishing topic: /map2815  
```
- at another terminal, `rostopic hz /audio` shows
```
...
average rate: 15.288
	min: 0.030s max: 0.242s std dev: 0.02018s window: 6447
average rate: 15.289
	min: 0.030s max: 0.242s std dev: 0.02016s window: 6462
average rate: 15.290
	min: 0.030s max: 0.242s std dev: 0.02016s window: 6479
average rate: 15.290
	min: 0.030s max: 0.242s std dev: 0.02016s window: 6494
average rate: 15.291
	min: 0.030s max: 0.242s std dev: 0.02016s window: 6510
average rate: 15.292
	min: 0.030s max: 0.242s std dev: 0.02016s window: 6526
average rate: 15.293
	min: 0.030s max: 0.242s std dev: 0.02014s window: 6541
average rate: 15.294
	min: 0.030s max: 0.242s std dev: 0.02011s window: 6557
...
```
- at another terminal `rosnode info /audio_play` shows
```
--------------------------------------------------------------------------------
Node [/audio_play]
Publications: 
 * /rosout [rosgraph_msgs/Log]

Subscriptions: 
 * /audio [audio_common_msgs/AudioData]
 * /clock [rosgraph_msgs/Clock]

Services: 
 * /audio_play/get_loggers
 * /audio_play/set_logger_level


contacting node http://oem-ThinkPad-T490:39695/ ...
Pid: 2375
Connections:
 * topic: /rosout
    * to: /rosout
    * direction: outbound (43069 - 127.0.0.1:42668) [10]
    * transport: TCPROS
 * topic: /clock
    * to: /rosbag_play (http://oem-ThinkPad-T490:37663/)
    * direction: inbound (42926 - oem-ThinkPad-T490:32863) [22]
    * transport: TCPROS
 * topic: /audio
    * to: /rosbag_play (http://oem-ThinkPad-T490:37663/)
    * direction: inbound (42986 - oem-ThinkPad-T490:32863) [24]
    * transport: TCPROS
```