### PR TITLE
[WIP] reduce resolution factor in go_to_kitchen classification result

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
@@ -11,6 +11,7 @@
       approximate_sync: true
       queue_size: 100
       use_classification_result: true
+      resolution_factor: 1.0
     </rosparam>
   </node>
 </launch>


### PR DESCRIPTION
The output video size of `xxx_go_to_kitchen_object_detection.avi` is 1280 x 960, although the original fetch's video size is 640 x 480.

I think the reason is that the default value of `resolution_factor` in `jsk_perception/draw_rects` is 2.0.

This may cause fetch's high CPU usage during drawing rects.

https://github.com/jsk-ros-pkg/jsk_recognition/blob/a6abfcc82be380fb70c80929461c58067f379967/jsk_perception/src/draw_rects.cpp#L159-L161

https://github.com/jsk-ros-pkg/jsk_recognition/blob/a6abfcc82be380fb70c80929461c58067f379967/jsk_perception/cfg/DrawRects.cfg#L44

I am sorry, but I have not tested this feature in go_to_kitchen demo.