### PR TITLE
[jsk_fetch_startup] Set speaker volume at jsk-fetch-startup.conf

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/upstart_scripts/jsk-fetch-startup.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/upstart_scripts/jsk-fetch-startup.conf
@@ -19,8 +19,6 @@ respawn
 # $ alsamixer
 # For fetch15's speaker
 env AUDIO_DEVICE="alsa_output.usb-1130_USB_AUDIO-00-AUDIO.analog-stereo"
-# For fetch1075's speaker
-# env AUDIO_DEVICE="alsa_output.usb-1130_USB_AUDIO-00-AUDIO.iec958-stereo"
 
 env ROSCONSOLE_FORMAT="[${severity}] [${time}] [${node}:${logger}]: ${message}"
 
@@ -28,7 +26,9 @@ env ROSCONSOLE_FORMAT="[${severity}] [${time}] [${node}:${logger}]: ${message}"
 pre-start script
     # launch by fetch user: yamaguchi & s-kitagawa (2019/04/18)
     # exec su ros -c "pactl set-default-sink $AUDIO_DEVICE || true"
-    exec su fetch -c "pactl set-default-sink $AUDIO_DEVICE || true"
+    # Make sure that you choose 'Analog Output USB AUDIO'
+    # at GUI settings (Settings -> Sound -> Play sound through)
+    exec su fetch -c "pactl set-default-sink $AUDIO_DEVICE || true && pactl set-sink-volume $AUDIO_DEVICE 100% || true"
 end script
 
 script


### PR DESCRIPTION
In this PR, I did
- Use the same AUDIO_DEVICE name for fetch15 and fetch1075
- Set speaker volume in pre-start script

For the first, I misunderstood the AUDIO_DEVICE name in the past PR (#39)
I found that the output of `$ pactl list` is different when we select Analog Output and Digital Output at GUI Settings.
![sound_setting](https://user-images.githubusercontent.com/19769486/99530848-334f0b80-29e5-11eb-961c-de677fe068de.png)

When we select Analog Output at GUI Settings:
```
$ pactl list | grep Name | grep 1130
	Name: alsa_output.usb-1130_USB_AUDIO-00-AUDIO.analog-stereo
	Name: alsa_output.usb-1130_USB_AUDIO-00-AUDIO.analog-stereo.monitor
	Name: alsa_card.usb-1130_USB_AUDIO-00-AUDIO
```
When we select Digital Output at GUI Settings:
```
$ pactl list | grep Name | grep 1130
	Name: alsa_output.usb-1130_USB_AUDIO-00-AUDIO.iec958-stereo
	Name: alsa_output.usb-1130_USB_AUDIO-00-AUDIO.iec958-stereo.monitor
	Name: alsa_card.usb-1130_USB_AUDIO-00-AUDIO
```

I also found that when we select Digital Output at GUI, we cannot select analog output by `$ pactl set-default-sink` command.
For example,
```
$ pactl set-default-sink alsa_output.usb-1130_USB_AUDIO-00-AUDIO.analog-stereo
Failure: No such entity
```

I do not find good solution..
But I think we should keep `Analog Output USB AUDIO` at GUI setting.