### PR TITLE
Use RViz from source to use new type visualization_msgs/MarkerArray

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall
@@ -85,3 +85,7 @@
     local-name: ros-planning/navigation
     uri: https://github.com/ros-planning/navigation.git
     version: 708yamaguchi/fetch15
+- git:
+    local-name: ros-visualization/rviz
+    uri: https://github.com/ros-visualization/rviz.git
+    version: indigo-devel


### PR DESCRIPTION
In indigo, it seems that apt version rviz cannot show kinetic version `visualization_msgs/MarkerArray` even if we source kinetic version visualization_msgs workspace.
I think this PR is needed when we want to show `/spots_marker_array` on rviz inside fetch.