### PR TITLE
Create touchegg config files when catkin build

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/CMakeLists.txt
+++ b/jsk_fetch_robot/jsk_fetch_startup/CMakeLists.txt
@@ -41,6 +41,11 @@ macro(configure_icon_files icol iname)
   if(${_host_name} MATCHES "^${FETCH_NAME}")
     configure_file(config/RVizfetch.desktop.in
       $ENV{HOME}/Desktop/RViz${FETCH_NAME}.desktop)
+    # Multitouch gesture program for touchscrenn on Fetch's back
+    configure_file(config/touchegg.conf
+      $ENV{HOME}/.config/touchegg/touchegg.conf)
+    configure_file(config/touchegg.desktop
+      $ENV{HOME}/.config/autostart/touchegg.desktop)
   endif()
 endmacro(configure_icon_files)
 

--- a/jsk_fetch_robot/jsk_fetch_startup/config/touchegg.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/touchegg.conf
@@ -1,0 +1,53 @@
+<touchégg>
+	<settings>
+		<property name="composed_gestures_time">0</property>
+	</settings>
+	<application name="All">
+		<gesture type="DRAG" fingers="3" direction="RIGHT">
+			<action type="MOVE_WINDOW"></action>
+		</gesture>
+		<gesture type="DRAG" fingers="2" direction="ALL">
+			<action type="SCROLL">SPEED=7:INVERTED=false</action>
+		</gesture>
+		<gesture type="DRAG" fingers="3" direction="LEFT">
+			<action type="MOVE_WINDOW"></action>
+		</gesture>
+		<gesture type="PINCH" fingers="3" direction="ALL">
+			<action type="RESIZE_WINDOW"></action>
+		</gesture>
+		<gesture type="DRAG" fingers="3" direction="UP">
+			<action type="MAXIMIZE_RESTORE_WINDOW"></action>
+		</gesture>
+		<gesture type="TAP" fingers="3" direction="">
+			<action type="MOUSE_CLICK">BUTTON=2</action>
+		</gesture>
+		<gesture type="TAP" fingers="2" direction="">
+			<action type="MOUSE_CLICK">BUTTON=3</action>
+		</gesture>
+		<gesture type="DRAG" fingers="3" direction="DOWN">
+			<action type="MINIMIZE_WINDOW"></action>
+		</gesture>
+	</application>
+	<application name="Okular, Gwenview">
+		<gesture type="ROTATE" fingers="2" direction="LEFT">
+			<action type="SEND_KEYS">Control+L</action>
+		</gesture>
+		<gesture type="PINCH" fingers="2" direction="IN">
+			<action type="SEND_KEYS">Control+KP_Add</action>
+		</gesture>
+		<gesture type="PINCH" fingers="2" direction="OUT">
+			<action type="SEND_KEYS">Control+KP_Subtract</action>
+		</gesture>
+		<gesture type="ROTATE" fingers="2" direction="RIGHT">
+			<action type="SEND_KEYS">Control+R</action>
+		</gesture>
+	</application>
+	<application name="Dolphin, Chromium-browser">
+		<gesture type="DRAG" fingers="2" direction="RIGHT">
+			<action type="SEND_KEYS">Alt+Right</action>
+		</gesture>
+		<gesture type="DRAG" fingers="2" direction="LEFT">
+			<action type="SEND_KEYS">Alt+Left</action>
+		</gesture>
+	</application>
+</touchégg>

--- a/jsk_fetch_robot/jsk_fetch_startup/config/touchegg.desktop
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/touchegg.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Exec=touchegg
+Hidden=false
+NoDisplay=false
+X-GNOME-Autostart-enabled=true
+Name[en]=TouchEgg
+Name=TouchEgg
+Comment[en]=Adds touchpad gestures to Ubuntu.
+Comment=Adds touchpad gestures to Ubuntu.


### PR DESCRIPTION
The same as https://github.com/jsk-ros-pkg/jsk_robot/pull/1283

I add config files of touchegg (Multitouch gesture recognizer) for touchscreen on fetch's back.
The config files are placed when catkin build jsk_fetch_startup