### PR TITLE
Fix typo in rosbag_play.launch

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/rosbag_play.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/rosbag_play.launch
@@ -24,9 +24,9 @@
 
   <!-- decompress -->
   <node name="rgb_decompress" pkg="image_transport" type="republish"
-        args="compressed in:=$(arg RGB_IMAGE) out:=$(arg RGB_IMAGE)" />
+        args="compressed in:=$(arg RGB_IMAGE) raw out:=$(arg RGB_IMAGE)" />
   <node name="depth_decompress" pkg="image_transport" type="republish"
-        args="compressedDepth in:=$(arg DEPTH_IMAGE) out:=$(arg DEPTH_IMAGE)" />
+        args="compressedDepth in:=$(arg DEPTH_IMAGE) raw out:=$(arg DEPTH_IMAGE)" />
   <node pkg="nodelet" type="nodelet" name="point_cloud_xyzrgb"
         args="load depth_image_proc/point_cloud_xyzrgb $(arg manager)" output="screen" >
     <remap from="rgb/camera_info" to="$(arg RGB_CAMERA_INFO)" />


### PR DESCRIPTION
Without this pull request, compressed image topics are published too fast.
I checked with this rosbag:
https://drive.google.com/uc?id=1ozdwfJLHoA0ZmhDRRzVvpiHTOENzh7ZS

Rosbag play
```
$ roslaunch jsk_fetch_startup rosbag_play.launch rosbag:=/home/leus/Downloads/20201203100352_go_to_kitchen_rosbag.bag
```

Result
```
$ rostopic info /head_camera/rgb/throttled/image_rect_color/compressed
Type: sensor_msgs/CompressedImage

Publishers: 
 * /rgb_decompress (http://133.11.216.169:37609/)
 * /rosbag_play (http://133.11.216.169:45559/)

Subscribers: 
 * /rgb_decompress (http://133.11.216.169:37609/)
```

```
$ rostopic hz /head_camera/rgb/throttled/image_rect_color/compressed                
subscribed to [/head_camera/rgb/throttled/image_rect_color/compressed]         
WARNING: may be using simulated time                                                                 
average rate: 257.122                                                                    
        min: 0.000s max: 0.071s std dev: 0.00641s window: 255                       
average rate: 253.000                                                                                
        min: 0.000s max: 0.074s std dev: 0.00686s window: 505                       
^Caverage rate: 254.436                                                        
        min: 0.000s max: 0.074s std dev: 0.00681s window: 670    
```

I fixed typo. 
Reference:
https://github.com/jsk-ros-pkg/jsk_recognition/blob/2c1400e15d79b4f5f9fc7e6784a58bb277ebd8e3/jsk_pcl_ros/launch/openni2_remote.launch#L71-L76
http://wiki.ros.org/image_transport#Nodes
