### PR TITLE
Add playing time option to jsk_fetch_robot/launch/rosbag_play.launch

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/rosbag_play.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/rosbag_play.launch
@@ -7,6 +7,8 @@
   <arg name="gui" default="false" />
   <arg name="loop_flag" value="--loop" if="$(arg loop)" />
   <arg name="loop_flag" value="" unless="$(arg loop)" />
+  <arg name="start_time" default="0" />
+
   <arg name="audio_play" default="false" />
   <arg name="audio_device" default="" />
 
@@ -101,7 +103,7 @@
 
   <!-- rosbag player -->
   <node pkg="rosbag" type="play" name="rosbag_play"
-        args="$(arg rosbag) $(arg loop_flag) --clock" output="screen" />
+        args="$(arg rosbag) $(arg loop_flag) -s $(arg start_time) --clock" output="screen" />
 
   <node pkg="rviz" type="rviz" name="$(anon rviz)" if="$(arg gui)"
         args="-d $(find jsk_fetch_startup)/config/jsk_startup.rviz" />

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/rosbag_play.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/rosbag_play.launch
@@ -8,7 +8,9 @@
   <arg name="loop_flag" value="--loop" if="$(arg loop)" />
   <arg name="loop_flag" value="" unless="$(arg loop)" />
   <arg name="start_time" default="0" />
-
+  <arg name="duration_time" default="0" />
+  <arg name="duration" default="--duration $(arg duration_time)" if="$(eval duration_time != 0)" />
+  <arg name="duration" default="" if="$(eval duration_time == 0)" />
   <arg name="audio_play" default="false" />
   <arg name="audio_device" default="" />
 
@@ -103,7 +105,7 @@
 
   <!-- rosbag player -->
   <node pkg="rosbag" type="play" name="rosbag_play"
-        args="$(arg rosbag) $(arg loop_flag) -s $(arg start_time) --clock" output="screen" />
+        args="$(arg rosbag) $(arg loop_flag) --clock --start $(arg start_time) $(arg duration)" output="screen" />
 
   <node pkg="rviz" type="rviz" name="$(anon rviz)" if="$(arg gui)"
         args="-d $(find jsk_fetch_startup)/config/jsk_startup.rviz" />


### PR DESCRIPTION
To play the rosbag file for specific time, I add the option to set `duration_time` and `start_time`.
However the problem is that this PR doesn't support indigo, because of using the `eval` in launch file. So if there are proper solution for it, please tell me how to fix it. 