### PR TITLE
Enabled imu

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/pr2_bringup.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/pr2_bringup.launch
@@ -228,7 +228,7 @@
     <param name="sensor_timeout" value="1.0"/>
     <param name="publish_tf" value="true"/>
     <param name="odom_used" value="true"/>
-    <param name="imu_used" value="false"/> <!-- using Imu causes rolling -->
+    <param name="imu_used" value="true"/>
     <param name="vo_used" value="false"/>
     <remap from="odom" to="base_odometry/odom" />
     <remap from="imu_data" to="torso_lift_imu/data" />


### PR DESCRIPTION
 Enabled imu in robot_pose_ekf. The experiment procedure is as follows: (1) `sudo initctl restart robot` inside robot to reset the odometry. (2) Starting from the initial position, I moved the robot using the teleope controller, with rather higher speed. (3) Then, move back to the original position. 

If there is no error in the odometry, x and y components of the pose/position and z componet of the poes/orientation must be 0.0 in the final moment. 

The rosbag data can be found in 
https://drive.google.com/file/d/1baUnHyRQ2pYhE3G88SX3zIcZLBBXPnzC/view?usp=sharing
 The topic names starting from ishida_robot_pose_ekf are the ones using the imu, and those starting from robot_pose_ekf are the ones without imu. The following screenshot snaps the final moment, where you can observe for all components, the ones with imu outperforms the those without IMU. 

![hoge](https://user-images.githubusercontent.com/38597814/105814500-da0ee400-5ff4-11eb-8b2c-c1651a8be84d.png)

Additionally, to check the long-term effect, I conducted the experiment without moving the base.  
Also to check the long-term drifting is not caused, I gather the data for longer time. 
https://drive.google.com/drive/u/0/folders/1wIXWFlSHWGNVU6R9JFPXlYLedWYARrhe
The odom snapshot at the final moment is like the following, which implies there is no problem using imu. (at least for 10 mins order)
![hage](https://user-images.githubusercontent.com/38597814/105815758-c19fc900-5ff6-11eb-94c3-d96d765f1aa1.png)