### PR TITLE
Add script to copy supervisor config files to /etc/supervisor/conf.d

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/config/install_supervisor.sh
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/install_supervisor.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+jsk_fetch_startup=$(builtin cd "`dirname "${BASH_SOURCE[0]}"`"/.. > /dev/null && pwd)
+
+IFS=':' read -r -a prefix_paths <<< "$CMAKE_PREFIX_PATH"
+current_prefix_path="${prefix_paths[0]}"
+
+#
+cd $jsk_fetch_startup/supervisor_scripts
+for file in $(ls ./*.conf); do
+    sudo cp $file /etc/supervisor/conf.d/
+    sudo chown root:root /etc/supervisor/conf.d/$file
+    sudo chmod 644 /etc/supervisor/conf.d/$file
+    echo "copied $file to /etc/supervisor/conf.d"
+done


### PR DESCRIPTION
I checked that supervisor conf files are copied under `/etc/supervisor/conf.d`
```bash
$ ./install_supervisor.sh 
[sudo] password for fetch: 
copied ./jsk-app-scheduler.conf to /etc/supervisor/conf.d
copied ./jsk-coral.conf to /etc/supervisor/conf.d
copied ./jsk-dialog.conf to /etc/supervisor/conf.d
copied ./jsk-fetch-startup.conf to /etc/supervisor/conf.d
copied ./jsk-gdrive.conf to /etc/supervisor/conf.d
copied ./jsk-log-wifi.conf to /etc/supervisor/conf.d
copied ./jsk-network-monitor.conf to /etc/supervisor/conf.d
copied ./robot.conf to /etc/supervisor/conf.d
copied ./roscore.conf to /etc/supervisor/conf.d

$ sudo updatedb

$ locate jsk-coral.conf
/etc/supervisor/conf.d/jsk-coral.conf
/home/fetch/ros/melodic/src/jsk-ros-pkg/jsk_robot/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-coral.conf
/home/fetch/ros/melodic/src/jsk-ros-pkg/jsk_robot/jsk_fetch_robot/jsk_fetch_startup/upstart_scripts/jsk-coral.conf
```

I am not sure if there is a conf file to start supervisor daemon.
If this PR is enough, I will create PR to jsk-ros-pkg/jsk_robot