### PR TITLE
[jsk_fetch_startup] update odometry mux selector

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch.launch
@@ -57,14 +57,16 @@
       type="odometry_mux_selector.py"
       name="odometry_mux_selector"
       >
-      <param name="~topic_odom_initial" value="odom_visual" />
-      <param name="~topic_odom_backup" value="odom_robot_localization" />
-      <param name="~topic_tf_initial" value="tf_odom_visual" />
-      <param name="~topic_tf_backup" value="tf_odom_robot_localization" />
+      <param name="~topic_odom_primary" value="odom_visual" />
+      <param name="~topic_odom_secondary" value="odom_robot_localization" />
+      <param name="~topic_tf_primary" value="tf_odom_visual" />
+      <param name="~topic_tf_secondary" value="tf_odom_robot_localization" />
       <param name="~duration_timeout_topic" value="10.0" />
 
       <remap from="~select_service_topic" to="/odom_topic_mux/select" />
       <remap from="~select_service_tf" to="/odom_tf_mux/select" />
+
+      <remap from="~sound_play" to="sound_play" />
   </node>
 
   <!-- Odometry with robot localization ukf using wheel and imu -->

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/odometry_mux_selector.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/odometry_mux_selector.py
@@ -32,7 +32,7 @@ class OdometryMuxSelector(object):
             rospy.logerr('Service is not found:{}'.format(e))
             sys.exit(1)
 
-        self._soundhandle = SoundClient(blocking=True,sound_ation="sound_play")
+        self._soundhandle = SoundClient(blocking=True,sound_action="sound_play")
 
         try:
             rospy.wait_for_message(self._topic_odom_primary,Odometry,self._duration_timeout_topic)
@@ -42,6 +42,8 @@ class OdometryMuxSelector(object):
 
         self._srv_select_topic = rospy.ServiceProxy('~select_service_topic', MuxSelect)
         self._srv_select_tf = rospy.ServiceProxy('~select_service_tf', MuxSelect)
+
+        self._flag_secondary = False
 
         rospy.loginfo('odometry_mux_selector is up')
 

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/odometry_mux_selector.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/odometry_mux_selector.py
@@ -40,10 +40,6 @@ class OdometryMuxSelector(object):
         self._srv_select_topic = rospy.ServiceProxy('~select_service_topic', MuxSelect)
         self._srv_select_tf = rospy.ServiceProxy('~select_service_tf', MuxSelect)
 
-        self.r = rostopic.ROSTopicHz(-1)
-        rospy.Subscriber(self._topic_odom_primary, rospy.AnyMsg, self.r.callback_hz, callback_args=self._topic_odom_primary)
-        self._flag_secondary = False
-
         rospy.loginfo('odometry_mux_selector is up')
 
     def select(self, topic_odom, topic_tf):

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/odometry_mux_selector.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/odometry_mux_selector.py
@@ -9,6 +9,7 @@ import rostopic
 from topic_tools.srv import MuxSelect, MuxSelectRequest
 from nav_msgs.msg import Odometry
 from tf.msg import tfMessage
+from sound_play.libsoundplay import SoundClient
 
 class OdometryMuxSelector(object):
 
@@ -30,6 +31,8 @@ class OdometryMuxSelector(object):
         except rospy.ROSException as e:
             rospy.logerr('Service is not found:{}'.format(e))
             sys.exit(1)
+
+        self._soundhandle = SoundClient(blocking=True,sound_ation="sound_play")
 
         try:
             rospy.wait_for_message(self._topic_odom_primary,Odometry,self._duration_timeout_topic)
@@ -61,11 +64,13 @@ class OdometryMuxSelector(object):
             except rospy.ROSException as e:
                 if not self._flag_secondary:
                     rospy.logwarn('Primary topics "{}" or "{}" are not published. switched to secondary topics'.format(self._topic_odom_primary, self._topic_tf_primary))
+                    self._soundhandle.say("Switched to secondary odometry topics.")
                     self._flag_secondary = True
                     self.select( self._topic_odom_secondary, self._topic_tf_secondary )
             else:
                 if self._flag_secondary:
                     rospy.logwarn('Primary topics "{}" are now published. switched to primary topics'.format(self._topic_odom_primary, self._topic_tf_primary))
+                    self._soundhandle.say("Switched to primary odometry topics back again.")
                     self._flag_secondary = False
                     self.select( self._topic_odom_primary, self._topic_tf_primary )
 

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/odometry_mux_selector.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/odometry_mux_selector.py
@@ -8,7 +8,7 @@ import rostopic
 
 from topic_tools.srv import MuxSelect, MuxSelectRequest
 from nav_msgs.msg import Odometry
-from tf.msg import tfMessage
+from tf2_msgs.msg import TFMessage
 from sound_play.libsoundplay import SoundClient
 
 class OdometryMuxSelector(object):
@@ -36,7 +36,7 @@ class OdometryMuxSelector(object):
 
         try:
             rospy.wait_for_message(self._topic_odom_primary,Odometry,self._duration_timeout_topic)
-            rospy.wait_for_message(self._topic_tf_primary,tfMessage,self._duration_timeout_topic)
+            rospy.wait_for_message(self._topic_tf_primary,TFMessage,self._duration_timeout_topic)
         except rospy.ROSException as e:
             rospy.logwarn('Message is not published:{}'.format(e))
 
@@ -62,7 +62,7 @@ class OdometryMuxSelector(object):
             rate.sleep()
             try:
                 rospy.wait_for_message(self._topic_odom_primary,Odometry,self._duration_timeout_topic)
-                rospy.wait_for_message(self._topic_tf_primary,tfMessage,self._duration_timeout_topic)
+                rospy.wait_for_message(self._topic_tf_primary,TFMessage,self._duration_timeout_topic)
             except rospy.ROSException as e:
                 if not self._flag_secondary:
                     rospy.logwarn('Primary topics "{}" or "{}" are not published. switched to secondary topics'.format(self._topic_odom_primary, self._topic_tf_primary))

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/odometry_mux_selector.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/odometry_mux_selector.py
@@ -32,7 +32,9 @@ class OdometryMuxSelector(object):
             rospy.logerr('Service is not found:{}'.format(e))
             sys.exit(1)
 
-        self._soundhandle = SoundClient(blocking=True,sound_action="sound_play")
+        self._soundhandle = SoundClient(
+                                    sound_topic='robotsound',
+                                    sound_action='sound_play')
 
         try:
             rospy.wait_for_message(self._topic_odom_primary,Odometry,self._duration_timeout_topic)


### PR DESCRIPTION
- rename `initial topics` and `backup topics` to `primary topics` and `secondary topics`
- enable odometry_mux_selector to switch back to primary topics if primary topics are available again.
- enable odomtery_mux_selector to make a robot to speak when topics are switched.