### PR TITLE
add update_workspace.sh for fetch workspace nightly build

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/updata_workspace.sh
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/updata_workspace.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+. $HOME/ros/melodic/devel/setup.bash
+
+set -x
+
+cd $HOME/ros/melodic/src
+ln -sf $(rospack find jsk_fetch_startup)/../jsk_fetch.rosinstall.$ROS_DISTRO $HOME/ros/melodic/src/.rosinstall
+wstool update --delete-changed-uris --continue-on-error
+catkin build
+set +x


### PR DESCRIPTION
I add this script for crontab to update workspace at 3:00 AM every day.

```bash
# m h  dom mon dow   command
0 3 * * * /bin/bash -c ". /home/fetch/ros/melodic/devel/setup.bash && rosrun jsk_fetch_startup update_workspace.sh"
```

cc. @sktometometo 