### PR TITLE
catkin clean workspace after wstool update

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/update_workspace.sh
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/update_workspace.sh
@@ -9,6 +9,7 @@ ln -sf $(rospack find jsk_fetch_startup)/../jsk_fetch.rosinstall.$ROS_DISTRO $HO
 wstool foreach --git 'git stash'
 wstool update --delete-changed-uris
 cd $HOME/ros/melodic
+catkin clean -y
 catkin init
 catkin config -DCMAKE_BUILD_TYPE=Release
 catkin build

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/update_workspace.sh
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/update_workspace.sh
@@ -9,7 +9,7 @@ ln -sf $(rospack find jsk_fetch_startup)/../jsk_fetch.rosinstall.$ROS_DISTRO $HO
 wstool foreach --git 'git stash'
 wstool update --delete-changed-uris
 cd $HOME/ros/melodic
-catkin clean -y
+catkin clean aques_talk collada_urdf_jsk_patch -y
 catkin init
 catkin config -DCMAKE_BUILD_TYPE=Release
 catkin build


### PR DESCRIPTION
(日本語で失礼します)
このプルリクエストでは、wstool updateとcatkin buildの間にcatkin cleanを入れるようにしました。

今日気づいたのですが、fetch15とfetch1075がaques_talkで日本語を話せないという問題が発生していました。
/var/log/ros/jsk-fetch-startup.logには以下のようなログが残っていました。
```
Phont file  : /home/fetch/ros/melodic/src/jsk-ros-pkg/jsk_3rdparty/3rdparty/aques_talk/phont/aq_f1c.phont
Input file  : /tmp/_voice_text_15912.txt
Output file : /tmp/sound_play8dn1XL.wav
could not found phont file /home/fetch/ros/melodic/src/jsk-ros-pkg/jsk_3rdparty/3rdparty/aques_talk/phont/aq_f1c.phont
[ERROR] [1619510623.256105] [/sound_play_jp:rosout]: Sound synthesis failed. Is festival installed? Is a festival voice installed? Try running "rosdep satisfy sound_play|sh". Refer to http://wiki.ros.org/sound_play/Troubleshooting
[ERROR] [1619510623.257519] [/sound_play_jp:rosout]: Exception in actionlib callback: 'NoneType' object has no attribute 'command'
```

直接の原因としては、aques_talk/phontディレクトリに存在するべき.phontファイルがなかったからです。
その原因は、以下のとおりだと考えています。
1. jsk_3rdpartyのmasterに新しいコミットが追加される。
2. wstool updateでfetch体内のjsk_3rdparty(aques_talk)が新しくgit cloneされる。
3. この時、前まで存在していたaques_talk/phontディレクトリが空になる。
4. catkin buildでaques_talk/phontディレクトリ内に.phontファイルが生成されることが期待されるが、（おそらく）aques_talkがすでにbuildされている扱いになって新しくbuildされず、.phontファイルは生成されない。
https://github.com/jsk-ros-pkg/jsk_3rdparty/blob/27767817252febb8322a291be36042bc5c51c76f/3rdparty/aques_talk/CMakeLists.txt#L20-L29

実際、
```
catkin clean aques_talk
catkin build aques_talk
```
すると、上記の.phontファイルが無い問題は治り、fetchは日本語を話せるようになりました。

おそらく似たような原因で、`collada_urdf_jsk_patch`もcleanしてbuildしないとbuildが通らない問題が発生していました。（こちらは詳細な原因は調べられていません）

毎日catkin cleanすると時間がかかりそうだなぁという気もしますが、仕方ない気がしています。