### PR TITLE
Log dstat output

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-dstat.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-dstat.conf
@@ -1,0 +1,11 @@
+; Install dstat
+; sudo apt install dstat
+[program:jsk-dstat]
+command=/bin/bash -c "dstat -tcdgilmnprsTy"
+stopsignal=TERM
+autostart=true
+autorestart=false
+stdout_logfile=/var/log/ros/jsk-dstat.log
+stderr_logfile=/var/log/ros/jsk-dstat.log
+user=root
+priority=1


### PR DESCRIPTION
To investigate recent freeze of fetch1075, I add system logging job.

Sample output:
```
----system---- --total-cpu-usage-- -dsk/total- ---paging-- ----interrupts--- ---load-avg--- ------memory-usage----- -net/total- ---procs--- --io/total- ----swap--- --epoch--- ---system--                                                                            
     time     |usr sys idl wai stl| read  writ|  in   out | 130   131   132 | 1m   5m  15m | used  free  buff  cach| recv  send|run blk new| read  writ| used  free|  epoch   | int   csw                                                                             
30-04 01:11:57| 10   1  89   0   0|   0     0 |   0     0 |  14     0    83 |0.85 0.78 0.73|2904M 9927M  855M 1941M| 380B  616B|  0   0   0|   0     0 |   0  2048M|1619712718| 924  2209                                                                             
30-04 01:11:58|  7   2  91   0   0|   0     0 |   0     0 |   7     0    54 |0.85 0.78 0.73|2899M 9933M  855M 1935M| 204B  244B|1.0   0   0|   0     0 |   0  2048M|1619712719| 800  1816
```