### PR TITLE
Record panorama video in go_to_kitchen demo

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -27,6 +27,13 @@ plugins:
       video_title: go_to_kitchen_object_detection.avi
       video_topic_name: /edgetpu_object_detector_visualization/output
       video_fps: 5.0
+  - name: panorama_video_recorder_plugin
+    type: app_recorder/video_recorder_plugin
+    launch_args:
+      video_path: /tmp
+      video_title: go_to_kitchen_panorama.avi
+      video_topic_name: /dual_fisheye_to_panorama/output
+      video_fps: 1.0
   - name: respeaker_audio_recorder_plugin
     type: app_recorder/audio_recorder_plugin
     launch_args:
@@ -77,12 +84,14 @@ plugins:
         - /tmp/go_to_kitchen_result.yaml
         - /tmp/go_to_kitchen_head_camera.avi
         - /tmp/go_to_kitchen_object_detection.avi
+        - /tmp/go_to_kitchen_panorama.avi
         - /tmp/go_to_kitchen_audio.wav
         - /tmp/go_to_kitchen_rosbag.bag
       upload_file_titles:
         - go_to_kitchen_result.yaml
         - go_to_kitchen_head_camera.avi
         - go_to_kitchen_object_detection.avi
+        - go_to_kitchen_panorama.avi
         - go_to_kitchen_audio.wav
         - go_to_kitchen_rosbag.bag
       upload_parents_path: fetch_go_to_kitchen
@@ -101,6 +110,7 @@ plugin_order:
   start_plugin_order:
     - head_camera_video_recorder_plugin
     - object_detection_video_recorder_plugin
+    - panorama_video_recorder_plugin
     - respeaker_audio_recorder_plugin
     - rosbag_recorder_plugin
     - result_recorder_plugin
@@ -110,6 +120,7 @@ plugin_order:
   stop_plugin_order:
     - head_camera_video_recorder_plugin
     - object_detection_video_recorder_plugin
+    - panorama_video_recorder_plugin
     - respeaker_audio_recorder_plugin
     - rosbag_recorder_plugin
     - result_recorder_plugin


### PR DESCRIPTION
In this PR, panorama video is recorded with 1.0 fps.

Please see the mail `Fetch kitchen patrol demo: 2021/05/12 (16:55:25)`