### PR TITLE
Check if voice_text is installed or not

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-fetch-startup.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-fetch-startup.conf
@@ -1,5 +1,5 @@
 [program:jsk-fetch-startup]
-command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && rosrun jsk_fetch_startup setup_audio.bash && roslaunch jsk_fetch_startup fetch_bringup.launch boot_sound:=true use_voice_text:=false --wait"
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && rosrun jsk_fetch_startup setup_audio.bash && if [ -d /usr/vt ]; then VOICE_TEXT=true; else VOICE_TEXT=false; fi && roslaunch jsk_fetch_startup fetch_bringup.launch boot_sound:=true use_voice_text:=$VOICE_TEXT --wait"
 stopsignal=TERM
 directory=/home/fetch/ros/melodic
 autostart=true


### PR DESCRIPTION
If `voice_text` is installed, `roslaunch jsk_fetch_startup fetch_brintup.launch use_voice_text:=true`
Now, with this branch, fetch15 speaks Japanese with aques_talk and fetch1075 speaks Japanese with voice_text.

If there is no problem with this programming style, please merge this PR.