### PR TITLE
Throttle insta360 image to reduce dual_fisheye_to_panorama CPU load

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -42,10 +42,16 @@
     local-name: jsk-ros-pkg/jsk_pr2eus
     uri: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
     version: master
+# we need to use the development branch (throttle-insta360 branch in 708yamaguchi's fork)
+# Restore jsk-ros-pkg/jsk_recognition master branch if https://github.com/jsk-ros-pkg/jsk_recognition/pull/2596 is merged.
+# - git:
+#     local-name: jsk-ros-pkg/jsk_recognition
+#     uri: https://github.com/jsk-ros-pkg/jsk_recognition.git
+#     version: master
 - git:
     local-name: jsk-ros-pkg/jsk_recognition
-    uri: https://github.com/jsk-ros-pkg/jsk_recognition.git
-    version: master
+    uri: https://github.com/708yamaguchi/jsk_recognition.git
+    version: throttle-insta360
 # we need to use the development branch (fetch15 branch in knorth55's fork)
 # until it is merged to master
 - git:

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_insta360_melodic.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_insta360_melodic.launch
@@ -8,6 +8,7 @@
     <!-- $ v4l2-ctl -d /dev/insta360 -\-list-formats-ext -->
     <arg name="height" value="736" />
     <arg name="width" value="1472" />
+    <arg name="throttle" value="true" />
     <!-- for melodic -->
     <arg name="use_usb_cam" value="false" />
   </include>


### PR DESCRIPTION
I check https://github.com/jsk-ros-pkg/jsk_recognition/pull/2596
Because dual_fisheye_to_panorama with no-throttled insta360 image takes high CPU usage, go_to_kitchen navigation with recording `/dual_fisheye_to_panorama/output` is slow.

I will keep an eye on this for a week.