### PR TITLE
Fetch speaks to Google Home in English to improve recognition accuracy

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -174,8 +174,11 @@
     (if initial-light-on
       (send *ri* :speak-jp "すでに電気がついています。" :wait t)
       (progn
-        (send *ri* :speak-jp "オッケー、グーグル" :wait t)
-        (send *ri* :speak-jp "電気をつけて" :wait t))))
+        ;; The accuracy of Google Home recognition is better in English than in Japanese.
+        ;; (send *ri* :speak-jp "オッケー、グーグル" :wait t)
+        ;; (send *ri* :speak-jp "電気をつけて" :wait t)
+        (send *ri* :speak "OK, Google" :wait t)
+        (send *ri* :speak "Turn on the light." :wait t))))
     (unix::sleep 1)
     ;; stove
     (dotimes (i n-kitchen-trial)
@@ -224,7 +227,10 @@
     (setq success-auto-dock (auto-dock :n-trial n-dock-trial))
     (when (and success-auto-dock (not initial-light-on))
       (unix::sleep 1)
-      (send *ri* :speak-jp "オッケー、グーグル" :wait t)
-      (send *ri* :speak-jp "電気を消して" :wait t))
+      ;; The accuracy of Google Home recognition is better in English than in Japanese.
+      ;; (send *ri* :speak-jp "オッケー、グーグル" :wait t)
+      ;; (send *ri* :speak-jp "電気を消して" :wait t)
+      (send *ri* :speak "OK, Google" :wait t)
+      (send *ri* :speak "Turn off the light." :wait t))
     (unix::sleep 1)
     (and success-go-to-kitchen success-auto-dock)))


### PR DESCRIPTION
本当はfetchが日本語でgoogle homeに話しかけてほしかったのですが、英語の方が圧倒的に認識精度が良さげなので、英語でgoogle homeに話しかけます。
voice textは自然な日本語だと思うので、voice textがfestivalに劣っているというよりは、google homeが英語を認識しやすいのだと思っています。
とりあえず1週間ほど毎朝のキッチンデモで様子を見つつ、可能であれば日本語で話しかけられるような工夫をします。
