### PR TITLE
Save dstat output in csv format

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/config/install_supervisor.sh
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/install_supervisor.sh
@@ -15,4 +15,7 @@ for file in $(ls ./*.conf); do
     echo "copied $file to /etc/supervisor/conf.d"
 done
 
+# Enable jsk_dstat job to save the csv log under /var/log
+ln -s /home/fetch/Documents/jsk_dstat.csv /var/log/ros/jsk_dstat.csv
+
 set +x

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/dstat.bash
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/dstat.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Keep only the last 1000 lines of csv log before executing dstat
+CSV_FILE=/home/fetch/Documents/jsk_dstat.csv
+
+if [ -e $CSV_FILE ]; then
+    cp -f $CSV_FILE $CSV_FILE.bk
+    tail -n 1000 $CSV_FILE.bk > $CSV_FILE
+    rm -f $CSV_FILE.bk
+else
+    touch $CSV_FILE
+fi
+
+dstat -tl --cpufreq -c -C all --top-cpu-adv -dgimnprsTy --output $CSV_FILE

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-dstat.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-dstat.conf
@@ -1,7 +1,7 @@
 ; Install dstat
 ; sudo apt install dstat
 [program:jsk-dstat]
-command=/bin/bash -c "dstat -tl --cpufreq -c -C all --top-cpu-adv -dgimnprsTy"
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && rosrun jsk_fetch_startup dstat.bash"
 stopsignal=TERM
 autostart=true
 autorestart=false


### PR DESCRIPTION
I save the dstat output in csv format to `/home/fetch/Documents/jsk_dstat.csv`.
Then, I create symbolic link from `/home/fetch/Documents/jsk_dstat.csv` to `/var/log/ros/jsk_dstat.csv`.
This csv log keeps 1000 lines everytime before executing dstat, so that the csv log does not become too long.