### PR TITLE
Check if the ROS topics using the fetch device are published.

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/config/test_device_topics.yaml
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/test_device_topics.yaml
@@ -19,11 +19,14 @@ timeout_5: 10
 topic_6: /head_camera/depth/image_raw
 timeout_6: 10
 
-topic_7: /imu
+topic_7: /head_camera/rgb/image_raw
 timeout_7: 10
 
-topic_8: /insta360/image_raw
+topic_8: /imu
 timeout_8: 10
 
-topic_9: /tf
+topic_9: /insta360/image_raw
 timeout_9: 10
+
+topic_10: /tf
+timeout_10: 10

--- a/jsk_fetch_robot/jsk_fetch_startup/config/test_device_topics.yaml
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/test_device_topics.yaml
@@ -1,0 +1,29 @@
+topic_0: /audio
+timeout_0: 10
+
+topic_1: /base_scan
+timeout_1: 10
+
+topic_2: /battery_state
+timeout_2: 10
+
+topic_3: /edgetpu_human_pose_estimator/output/image
+timeout_3: 10
+
+topic_4: /edgetpu_object_detector/output/image
+timeout_4: 10
+
+topic_5: /gripper/imu
+timeout_5: 10
+
+topic_6: /head_camera/depth/image_raw
+timeout_6: 10
+
+topic_7: /imu
+timeout_7: 10
+
+topic_8: /insta360/image_raw
+timeout_8: 10
+
+topic_9: /tf
+timeout_9: 10

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_test_topics.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_test_topics.launch
@@ -1,0 +1,9 @@
+<!-- Check if the ROS topics using the fetch device are published. -->
+<!-- Usage: roslaunch jsk_fetch_startup fetch_test_topics.launch -->
+
+<launch>
+  <node name="test_device_topics"
+        pkg="jsk_tools" type="test_topic_published.py" output="screen">
+    <rosparam command="load" file="$(find jsk_fetch_startup)/config/test_device_topics.yaml" />
+  </node>
+</launch>


### PR DESCRIPTION
I add roslaunch file to check if the ROS topics using the fetch device are published.
Do you think these topics are enough to check? @knorth55 

Usage:
```
$ roslaunch jsk_fetch_startup fetch_test_topics.launch
... logging to /home/leus/.ros/log/96e394e0-b973-11eb-98f0-69bcbf5551e9/roslaunch-b4apc-28170.log
Checking log directory for disk usage. This may take a while.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

started roslaunch server http://133.11.216.169:41583/

SUMMARY
========

PARAMETERS
 * /rosdistro: melodic
 * /rosversion: 1.14.10
 * /test_device_topics/timeout_0: 10
 * /test_device_topics/timeout_1: 10
 * /test_device_topics/timeout_2: 10
 * /test_device_topics/timeout_3: 10
 * /test_device_topics/timeout_4: 10
 * /test_device_topics/timeout_5: 10
 * /test_device_topics/timeout_6: 10
 * /test_device_topics/timeout_7: 10
 * /test_device_topics/timeout_8: 10
 * /test_device_topics/timeout_9: 10
 * /test_device_topics/topic_0: /audio
 * /test_device_topics/topic_1: /base_scan
 * /test_device_topics/topic_2: /battery_state
 * /test_device_topics/topic_3: /edgetpu_human_po...
 * /test_device_topics/topic_4: /edgetpu_object_d...
 * /test_device_topics/topic_5: /gripper/imu
 * /test_device_topics/topic_6: /head_camera/dept...
 * /test_device_topics/topic_7: /imu
 * /test_device_topics/topic_8: /insta360/image_raw
 * /test_device_topics/topic_9: /tf

NODES
  /
    test_device_topics (jsk_tools/test_topic_published.py)

ROS_MASTER_URI=http://fetch1075:11311

process[test_device_topics-1]: started with pid [28179]
[ROSUNIT] Outputting test results to /home/leus/.ros/test_results/jsk_tools/rosunit-test_topic_published.xml
[Testcase: test_published] ... ok
-------------------------------------------------------------
SUMMARY:
 * RESULT: SUCCESS
 * TESTS: 1
 * ERRORS: 0 []
 * FAILURES: 0 []

[test_device_topics-1] process has finished cleanly
log file: /home/leus/.ros/log/96e394e0-b973-11eb-98f0-69bcbf5551e9/test_device_topics-1*.log
all processes on machine have died, roslaunch will exit
shutting down processing monitor...
... shutting down processing monitor complete
done
```