### PR TITLE
Modify go to kitchen

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -178,11 +178,18 @@
     (if initial-light-on
       (send *ri* :speak-jp "すでに電気がついています。" :wait t)
       (progn
+        ;; Look at Google Home
+        (send *fetch* :head :neck-y :joint-angle 89)
+        (send *ri* :angle-vector-raw (send *fetch* :angle-vector) 3000 :head-controller)
+        (send *ri* :wait-interpolation)
         ;; The accuracy of Google Home recognition is better in English than in Japanese.
         ;; (send *ri* :speak-jp "オッケー、グーグル" :wait t)
         ;; (send *ri* :speak-jp "電気をつけて" :wait t)
         (send *ri* :speak "OK, Google" :wait t)
-        (send *ri* :speak "Turn on the light." :wait t)))
+        (send *ri* :speak "Turn on the light." :wait t)
+        (send *fetch* :head :neck-y :joint-angle 0)
+        (send *ri* :angle-vector-raw (send *fetch* :angle-vector) 3000 :head-controller)
+        (send *ri* :wait-interpolation)))
     (unix::sleep 1)
     ;; change the inflation_radius
     (ros::set-dynamic-reconfigure-param
@@ -236,11 +243,18 @@
     (setq success-auto-dock (auto-dock :n-trial n-dock-trial))
     (when (and success-auto-dock (not initial-light-on))
       (unix::sleep 1)
+      ;; Look at Google Home
+      (send *fetch* :head :neck-y :joint-angle 89)
+      (send *ri* :angle-vector-raw (send *fetch* :angle-vector) 3000 :head-controller)
+      (send *ri* :wait-interpolation)
       ;; The accuracy of Google Home recognition is better in English than in Japanese.
       ;; (send *ri* :speak-jp "オッケー、グーグル" :wait t)
       ;; (send *ri* :speak-jp "電気を消して" :wait t)
       (send *ri* :speak "OK, Google" :wait t)
-      (send *ri* :speak "Turn off the light." :wait t))
+      (send *ri* :speak "Turn off the light." :wait t)
+      (send *fetch* :head :neck-y :joint-angle 0)
+      (send *ri* :angle-vector-raw (send *fetch* :angle-vector) 3000 :head-controller)
+      (send *ri* :wait-interpolation))
     (unix::sleep 5)
     ;; change the inflation_radius
     (ros::set-dynamic-reconfigure-param

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -192,10 +192,12 @@
         (send *ri* :wait-interpolation)))
     (unix::sleep 1)
     ;; change the inflation_radius
+    ;; Increase the global inflation to generate a path that is less sensitive to differences between the map shape and the actual object placement.
     (ros::set-dynamic-reconfigure-param
       "/move_base/global_costmap/inflater" "inflation_radius" :double 0.7)
+    ;; Decrease the local inflation to generate a path that allows the robot to pass close to the object.
     (ros::set-dynamic-reconfigure-param
-      "/move_base/local_costmap/inflater" "inflation_radius" :double 0.7)
+      "/move_base/local_costmap/inflater" "inflation_radius" :double 0.35)
     ;; stove
     (dotimes (i n-kitchen-trial)
       (setq success-go-to-kitchen

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
@@ -71,7 +71,11 @@
   </group>
 
   <!-- Do not publish /base_controller/command if fetch is docking -->
-  <node pkg="jsk_fetch_startup" name="warning" type="warning.py" respawn="true" />
+  <node pkg="jsk_fetch_startup" name="warning" type="warning.py" respawn="true">
+    <rosparam>
+      volume: 0.3
+    </rosparam>
+  </node>
 
   <!-- copied for button mapping is changed to standardize with PR2 joy. -->
   <node name="controller_reset" pkg="fetch_bringup" type="controller_reset.py">

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/warning.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/warning.py
@@ -39,6 +39,7 @@ def terminate_thread(thread):
 class DiagnosticsSpeakThread(threading.Thread):
     def __init__(self, error_status):
         threading.Thread.__init__(self)
+        self.volume = rospy.get_param("~volume", 1.0)
         self.error_status = error_status
         self.start()
 
@@ -62,7 +63,7 @@ class DiagnosticsSpeakThread(threading.Thread):
             text = "Error on {}, {}".format(status.name, status.message)
             rospy.loginfo(text)
             text = text.replace('_', ', ')
-            sound.say(text, 'voice_kal_diphone')
+            sound.say(text, 'voice_kal_diphone', volume=self.volume)
             time.sleep(5)
 
     def stop(self):
@@ -110,9 +111,9 @@ class Warning:
         self.battery_state_msgs = msg
         #
         if msg.is_charging == False and msg.charge_level < 0.1:
-            sound.play(2)
+            sound.play(2, volume=self.volume)
             time.sleep(2)
-            sound.play(5)
+            sound.play(5, volume=self.volume)
             time.sleep(5)
 
     def cmd_vel_callback(self, msg):
@@ -130,7 +131,7 @@ class Warning:
            self.auto_undocking != True:
             rospy.logerr("Try to run while charging!")
             self.base_breaker(BreakerCommandRequest(enable=False))
-            sound.play(4) # play builtin sound Boom!
+            sound.play(4, volume=self.volume) # play builtin sound Boom!
             time.sleep(5)
             self.base_breaker(BreakerCommandRequest(enable=True))
         else:


### PR DESCRIPTION
- Add rosparam to select volume in warning.py to make error voice quiet
- Look at Google Home before talking in go-to-kitchen
- Smaller inflation radius in go-to-kitchen for smooth navigation

Please see "Fetch kitchen patrol demo: 2021/06/02 (01:28:23)"