### PR TITLE
Add jsk-lifelog job

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/config/install_supervisor.sh
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/install_supervisor.sh
@@ -16,6 +16,6 @@ for file in $(ls ./*.conf); do
 done
 
 # Enable jsk_dstat job to save the csv log under /var/log
-ln -s /home/fetch/Documents/jsk_dstat.csv /var/log/ros/jsk_dstat.csv
+ln -s /home/fetch/Documents/jsk_dstat.csv /var/log/ros/jsk-dstat.csv
 
 set +x

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -76,12 +76,6 @@
     <param name="buffer_size" value="120.0"/>
   </node>
 
-  <!-- logging -->
-  <include file="$(find jsk_fetch_startup)/launch/fetch_lifelog.xml" if="$(arg fetch_lifelog)">
-    <arg name="map_frame" value="$(arg map_frame)" />
-    <arg name="vital_check" value="false" />
-  </include>
-
   <!-- diagnostic aggregator -->
   <node pkg="diagnostic_aggregator" type="aggregator_node"
         name="diag_agg" args="CPP" output="screen" >

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-lifelog.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-lifelog.conf
@@ -1,0 +1,12 @@
+[program:jsk-lifelog]
+; Before start, wait for '/robot/name' rosparam to be set
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && rosrun jsk_fetch_startup wait_app_manager.bash && roslaunch jsk_fetch_startup fetch_lifelog.xml map_frame:=eng2 vital_check:=false"
+stopsignal=TERM
+directory=/home/fetch/ros/melodic
+autostart=true
+autorestart=false
+stdout_logfile=/var/log/ros/jsk-lifelog.log
+stderr_logfile=/var/log/ros/jsk-lifelog.log
+user=fetch
+environment=ROSCONSOLE_FORMAT="[${severity}] [${time}] [${node}:${logger}]: ${message}",PYTHONUNBUFFERED=1
+priority=200

--- a/jsk_fetch_robot/jsk_fetch_startup/tmuxinator_yaml/log.yml
+++ b/jsk_fetch_robot/jsk_fetch_startup/tmuxinator_yaml/log.yml
@@ -43,3 +43,4 @@ windows:
   - jsk-dialog: tail -f -n 1000 /var/log/ros/jsk-dialog.log
   - jsk-gdrive: tail -f -n 1000 /var/log/ros/jsk-gdrive.log
   - jsk-dstat: tail -f -n 1000 /var/log/ros/jsk-dstat.log
+  - jsk-lifelog: tail -f -n 1000 /var/log/ros/jsk-lifelog.log


### PR DESCRIPTION
I Add `jsk-lifelog` supervisor job because `$(find jsk_fetch_startup)/launch/fetch_lifelog.xml` sometimes outputs long errors.