### PR TITLE
Add supervisor job for edgetpu-panorama recognition

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -25,7 +25,7 @@ plugins:
     launch_args:
       video_path: /tmp
       video_title: go_to_kitchen_object_detection.avi
-      video_topic_name: /edgetpu_object_detector_visualization/output
+      video_topic_name: /edgetpu_object_detector/output/image
       video_fps: 5.0
   - name: panorama_video_recorder_plugin
     type: app_recorder/video_recorder_plugin

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -21,12 +21,20 @@ plugins:
       video_framerate: 30
       video_encoding: RGB
   - name: object_detection_video_recorder_plugin
-    type: app_recorder/video_recorder_plugin
+    type: app_recorder/audio_video_recorder_plugin
     launch_args:
       video_path: /tmp
       video_title: go_to_kitchen_object_detection.avi
+      audio_topic_name: /audio
+      audio_channels: 1
+      audio_sample_rate: 16000
+      audio_format: wave
+      audio_sample_format: S16LE
       video_topic_name: /edgetpu_object_detector/output/image
-      video_fps: 5.0
+      video_height: 480
+      video_width: 640
+      video_framerate: 10
+      video_encoding: RGB
   - name: panorama_video_recorder_plugin
     type: app_recorder/video_recorder_plugin
     launch_args:

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
@@ -1,17 +1,4 @@
 <launch>
   <node name="go_to_kitchen" pkg="roseus" type="roseus" required="true" output="screen"
         args="$(find jsk_fetch_startup)/euslisp/go-to-kitchen.l" />
-
-  <node name="edgetpu_object_detector_visualization" pkg="jsk_perception"
-        type="draw_rects" output="screen" respawn="true">
-    <remap from="~input" to="/head_camera/rgb/throttled/image_rect_color" />
-    <remap from="~input/rects" to="/edgetpu_object_detector/output/rects" />
-    <remap from="~input/class" to="/edgetpu_object_detector/output/class" />
-    <rosparam>
-      approximate_sync: true
-      queue_size: 100
-      use_classification_result: true
-      resolution_factor: 1.0
-    </rosparam>
-  </node>
 </launch>

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
@@ -1,4 +1,9 @@
 <launch>
   <node name="go_to_kitchen" pkg="roseus" type="roseus" required="true" output="screen"
         args="$(find jsk_fetch_startup)/euslisp/go-to-kitchen.l" />
+
+  <node name="go_to_kitchen_object_detector_score_thresh" pkg="dynamic_reconfigure" type="dynparam"
+        args="set_from_parameters edgetpu_object_detector">
+    <param name="score_thresh" type="double" value="0.80" /> <!-- default: 0.6 -->
+  </node>
 </launch>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_insta360_indigo.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_insta360_indigo.launch
@@ -11,4 +11,20 @@
     <!-- for indigo -->
     <arg name="use_usb_cam" value="true" />
   </include>
+
+  <group ns="dual_fisheye_to_panorama">
+    <node name="panorama_downsample_quater"
+          pkg="nodelet" type="nodelet"
+          args="standalone image_proc/resize"
+          respawn="true">
+      <remap from="image" to="output" />
+      <remap from="~image" to="quater/output" />
+      <remap from="~camera_info" to="quater/camera_info" />
+      <rosparam>
+        scale_width: 0.25
+        scale_height: 0.25
+      </rosparam>
+    </node>
+  </group>
+
 </launch>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_insta360_melodic.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_insta360_melodic.launch
@@ -12,4 +12,20 @@
     <!-- for melodic -->
     <arg name="use_usb_cam" value="false" />
   </include>
+
+  <group ns="dual_fisheye_to_panorama">
+    <node name="panorama_downsample_quater"
+          pkg="nodelet" type="nodelet"
+          args="standalone image_proc/resize"
+          respawn="true">
+      <remap from="image" to="output" />
+      <remap from="~image" to="quater/output" />
+      <remap from="~camera_info" to="quater/camera_info" />
+      <rosparam>
+        scale_width: 0.25
+        scale_height: 0.25
+      </rosparam>
+    </node>
+  </group>
+
 </launch>

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-human-pose-estimator.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-human-pose-estimator.conf
@@ -3,6 +3,7 @@ command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/cor
 
 stopsignal=TERM
 directory=/home/fetch/ros/coral_ws
+; You can set "autostart=true" if "autostart=false" in jsk-panorama-human-pose-estimator.conf
 autostart=true
 autorestart=false
 stdout_logfile=/var/log/ros/jsk-human-pose-estimator.log

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-object-detector.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-object-detector.conf
@@ -3,6 +3,7 @@ command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/cor
 
 stopsignal=TERM
 directory=/home/fetch/ros/coral_ws
+; You can set "autostart=true" if "autostart=false" in jsk-panorama-object-detector.conf
 autostart=true
 autorestart=false
 stdout_logfile=/var/log/ros/jsk-object-detector.log

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-panorama-human-pose-estimator.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-panorama-human-pose-estimator.conf
@@ -1,5 +1,5 @@
 [program:jsk-panorama-human-pose-estimator]
-command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/coral_ws/devel/setup.bash && roslaunch coral_usb edgetpu_panorama_human_pose_estimator.launch namespace:=edgetpu_human_pose_estimator INPUT_IMAGE:=/dual_fisheye_to_panorama/quater/output device_id:=0 --screen --wait"
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/coral_ws/devel/setup.bash && roslaunch coral_usb edgetpu_panorama_human_pose_estimator.launch nodename:=edgetpu_human_pose_estimator INPUT_IMAGE:=/dual_fisheye_to_panorama/quater/output device_id:=0 --screen --wait"
 
 stopsignal=TERM
 directory=/home/fetch/ros/coral_ws

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-panorama-human-pose-estimator.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-panorama-human-pose-estimator.conf
@@ -1,5 +1,5 @@
 [program:jsk-panorama-human-pose-estimator]
-command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/coral_ws/devel/setup.bash && roslaunch coral_usb edgetpu_panorama_human_pose_estimator.launch namespace:=edgetpu_human_pose_estimator INPUT_IMAGE:=/dual_fisheye_to_panorama/output device_id:=0 --screen --wait"
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/coral_ws/devel/setup.bash && roslaunch coral_usb edgetpu_panorama_human_pose_estimator.launch namespace:=edgetpu_human_pose_estimator INPUT_IMAGE:=/dual_fisheye_to_panorama/quater/output device_id:=0 --screen --wait"
 
 stopsignal=TERM
 directory=/home/fetch/ros/coral_ws

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-panorama-human-pose-estimator.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-panorama-human-pose-estimator.conf
@@ -1,0 +1,13 @@
+[program:jsk-panorama-human-pose-estimator]
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/coral_ws/devel/setup.bash && roslaunch coral_usb edgetpu_panorama_human_pose_estimator.launch namespace:=edgetpu_human_pose_estimator INPUT_IMAGE:=/dual_fisheye_to_panorama/output device_id:=0 --screen --wait"
+
+stopsignal=TERM
+directory=/home/fetch/ros/coral_ws
+; You can set "autostart=true" if "autostart=false" in jsk-human-pose-estimator.conf
+autostart=false
+autorestart=false
+stdout_logfile=/var/log/ros/jsk-panorama-human-pose-estimator.log
+stderr_logfile=/var/log/ros/jsk-panorama-human-pose-estimator.log
+user=fetch
+environment=ROSCONSOLE_FORMAT="[${severity}] [${time}] [${node}:${logger}]: ${message}",PYTHONUNBUFFERED=1
+priority=200

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-panorama-object-detector.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-panorama-object-detector.conf
@@ -1,5 +1,5 @@
 [program:jsk-panorama-object-detector]
-command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/coral_ws/devel/setup.bash && roslaunch coral_usb edgetpu_panorama_object_detector.launch namespace:=edgetpu_object_detector INPUT_IMAGE:=/dual_fisheye_to_panorama/quater/output model_file:=/home/fetch/.ros/data/coral_usb/mobilenet_v2_ssd_73b2_kitchen_finetuning_20200528.tflite label_file:=/home/fetch/.ros/data/coral_usb/73b2_kitchen_labels.txt device_id:=1 --screen --wait"
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/coral_ws/devel/setup.bash && roslaunch coral_usb edgetpu_panorama_object_detector.launch nodename:=edgetpu_object_detector INPUT_IMAGE:=/dual_fisheye_to_panorama/quater/output model_file:=/home/fetch/.ros/data/coral_usb/mobilenet_v2_ssd_73b2_kitchen_finetuning_20200528.tflite label_file:=/home/fetch/.ros/data/coral_usb/73b2_kitchen_labels.txt device_id:=1 --screen --wait"
 
 stopsignal=TERM
 directory=/home/fetch/ros/coral_ws

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-panorama-object-detector.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-panorama-object-detector.conf
@@ -1,5 +1,5 @@
 [program:jsk-panorama-object-detector]
-command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/coral_ws/devel/setup.bash && roslaunch coral_usb edgetpu_panorama_object_detector.launch namespace:=edgetpu_object_detector INPUT_IMAGE:=/dual_fisheye_to_panorama/output model_file:=/home/fetch/.ros/data/coral_usb/mobilenet_v2_ssd_73b2_kitchen_finetuning_20200528.tflite label_file:=/home/fetch/.ros/data/coral_usb/73b2_kitchen_labels.txt device_id:=1 --screen --wait"
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/coral_ws/devel/setup.bash && roslaunch coral_usb edgetpu_panorama_object_detector.launch namespace:=edgetpu_object_detector INPUT_IMAGE:=/dual_fisheye_to_panorama/quater/output model_file:=/home/fetch/.ros/data/coral_usb/mobilenet_v2_ssd_73b2_kitchen_finetuning_20200528.tflite label_file:=/home/fetch/.ros/data/coral_usb/73b2_kitchen_labels.txt device_id:=1 --screen --wait"
 
 stopsignal=TERM
 directory=/home/fetch/ros/coral_ws

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-panorama-object-detector.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-panorama-object-detector.conf
@@ -1,0 +1,13 @@
+[program:jsk-panorama-object-detector]
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/coral_ws/devel/setup.bash && roslaunch coral_usb edgetpu_panorama_object_detector.launch namespace:=edgetpu_object_detector INPUT_IMAGE:=/dual_fisheye_to_panorama/output model_file:=/home/fetch/.ros/data/coral_usb/mobilenet_v2_ssd_73b2_kitchen_finetuning_20200528.tflite label_file:=/home/fetch/.ros/data/coral_usb/73b2_kitchen_labels.txt device_id:=1 --screen --wait"
+
+stopsignal=TERM
+directory=/home/fetch/ros/coral_ws
+; You can set "autostart=true" if "autostart=false" in jsk-object-detector.conf
+autostart=false
+autorestart=false
+stdout_logfile=/var/log/ros/jsk-panorama-object-detector.log
+stderr_logfile=/var/log/ros/jsk-panorama-object-detector.log
+user=fetch
+environment=ROSCONSOLE_FORMAT="[${severity}] [${time}] [${node}:${logger}]: ${message}",PYTHONUNBUFFERED=1
+priority=200

--- a/jsk_fetch_robot/jsk_fetch_startup/tmuxinator_yaml/log.yml
+++ b/jsk_fetch_robot/jsk_fetch_startup/tmuxinator_yaml/log.yml
@@ -39,7 +39,9 @@ windows:
   - jsk-app-scheduler: tail -f -n 1000 /var/log/ros/jsk-app-scheduler.log
   # - jsk-coral: tail -f -n 1000 /var/log/ros/jsk-coral.log
   - jsk-object-detector: tail -f -n 1000 /var/log/ros/jsk-object-detector.log
+  - jsk-panorama-object-detector: tail -f -n 1000 /var/log/ros/jsk-panorama-object-detector.log
   - jsk-human-pose-estimator: tail -f -n 1000 /var/log/ros/jsk-human-pose-estimator.log
+  - jsk-panorama-human-pose-estimator: tail -f -n 1000 /var/log/ros/jsk-panorama-human-pose-estimator.log
   - jsk-dialog: tail -f -n 1000 /var/log/ros/jsk-dialog.log
   - jsk-gdrive: tail -f -n 1000 /var/log/ros/jsk-gdrive.log
   - jsk-dstat: tail -f -n 1000 /var/log/ros/jsk-dstat.log


### PR DESCRIPTION
I add supervisor jobs for edgetpu-panorama recognition.

In these jobs, I change namespace of published topics.
For example, 
`/edgetpu_panorama_object_detector/output/class` -> `/edgetpu_object_detector/output/class`

By this change, other programs (e.g. `object_detection_video_recorder_plugin`) can work without changing their configurations.

This PR depends on https://github.com/knorth55/coral_usb_ros/pull/60