### PR TITLE
use knorth55/app_manager@fetch15

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -1,10 +1,11 @@
 # This is rosinstall file for melodic PC inside fetch.
 # $ ln -s $(rospack find jsk_fetch_startup)/../jsk_fetch.rosinstall.$ROS_DISTRO $HOME/ros/$ROS_DISTRO/src/.rosinstall
 
+# we need https://github.com/PR2/app_manager/pull/31 to handle timeout
 - git:
     local-name: PR2/app_manager
-    uri: https://github.com/PR2/app_manager.git
-    version: kinetic-devel
+    uri: https://github.com/knorth55/app_manager.git
+    version: fetch15
 - git:
     local-name: RobotWebTools/rosbridge_suite
     uri: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
we need https://github.com/PR2/app_manager/pull/31 for timeout handling.
currently, fetch returns app result as below when app is timeout.

```yaml
exit_code: 0
stopped: null
```

I change this to set `stopped` `true` when app is timeout.