### PR TITLE
set longer timeout for time signal

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/apps/time_signal/time_signal.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/time_signal/time_signal.app
@@ -3,7 +3,7 @@ platform: fetch
 launch: jsk_fetch_startup/time_signal.xml
 interface: jsk_fetch_startup/time_signal.interface
 icon: jsk_fetch_startup/time_signal.png
-timeout: 10
+timeout: 120
 plugins:
   - name: tweet_notifier_plugin
     type: app_notifier/tweet_notifier_plugin


### PR DESCRIPTION
set longer timeout for time signal.
now, fetch stop speaking weather forecast in english because of this timeout.