### PR TITLE
return name of result state in go-to-kitchen-smach

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/go-to-kitchen.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/go-to-kitchen.l
@@ -3,18 +3,21 @@
 (require :fetch-interface "package://fetcheus/fetch-interface.l")
 (load "package://jsk_fetch_startup/euslisp/navigation-utils.l")
 
+
 (defun main (&key (tweet t) (n-dock-trial 3) (n-kitchen-trial 3) (control-switchbot :api))
   (when (not (boundp '*sm*))
     (go-to-kitchen-state-machine))
-  (exec-state-machine
-    *sm* `((tweet . ,tweet)
-           (n-kitchen-trial . ,n-kitchen-trial)
-           (n-dock-trial . ,n-dock-trial)
-           (control-switchbot . ,control-switchbot)
-           (initial-light-on . nil)
-           (success-go-to-kitchen . nil)
-           (success-auto-dock . nil))
-    :hz 2.0))
+  (let ((result-state
+          (exec-state-machine *sm* `((tweet . ,tweet)
+                                     (n-kitchen-trial . ,n-kitchen-trial)
+                                     (n-dock-trial . ,n-dock-trial)
+                                     (control-switchbot . ,control-switchbot)
+                                     (initial-light-on . nil)
+                                     (success-go-to-kitchen . nil)
+                                     (success-auto-dock . nil))
+                              :hz 2.0)))
+    (send result-state :name)))
+
 
 (ros::roseus "go_to_kitchen")
 (if (main) (unix::exit 0) (unix::exit 1))


### PR DESCRIPTION
return name of the result state.
name should be `t` or `nil`.