### PR TITLE
Do not replace sound when other node is speaking

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -71,10 +71,16 @@
     local-name: mikeferguson/robot_calibration
     uri: https://github.com/mikeferguson/robot_calibration.git
     version: 0.5.5
+# To use https://github.com/knorth55/audio_common/commit/0afc838d44e5e99d11de78f2315d5534ea732d18
+# Use ros-drivers master branch after https://github.com/ros-drivers/audio_common/pull/173 is merged.
 - git:
     local-name: ros-drivers/audio_common
-    uri: https://github.com/ros-drivers/audio_common.git
-    version: master
+    uri: https://github.com/knorth55/audio_common.git
+    version: fetch15
+# - git:
+#     local-name: ros-drivers/audio_common
+#     uri: https://github.com/ros-drivers/audio_common.git
+#     version: master
 - git:
     local-name: ros-perception/slam_gmapping
     uri: https://github.com/ros-perception/slam_gmapping.git

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/battery_warning.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/battery_warning.py
@@ -3,19 +3,15 @@
 
 import actionlib
 import rospy
+from sound_play.libsoundplay import SoundClient
 
 from power_msgs.msg import BatteryState
-from sound_play.msg import SoundRequest
-from sound_play.msg import SoundRequestAction
-from sound_play.msg import SoundRequestGoal
 
 
 class BatteryWarning(object):
     def __init__(self):
-        self.client_en = actionlib.SimpleActionClient(
-            '/sound_play', SoundRequestAction)
-        self.client_jp = actionlib.SimpleActionClient(
-            '/robotsound_jp', SoundRequestAction)
+        self.client_en = SoundClient(sound_action='/sound_play', blocking=True)
+        self.client_jp = SoundClient(sound_action='/robotsound_jp', blocking=True)
         self.duration = rospy.get_param('~duration', 180.0)
         self.threshold = rospy.get_param('~charge_level_threshold', 40.0)
         self.step = rospy.get_param('~charge_level_step', 10.0)
@@ -28,17 +24,13 @@ class BatteryWarning(object):
         self.is_charging = False
 
     def _speak(self, client, speech_text, lang=None):
-        client.wait_for_server(timeout=rospy.Duration(1.0))
-        sound_goal = SoundRequestGoal()
-        sound_goal.sound_request.sound = -3
-        sound_goal.sound_request.command = 1
-        sound_goal.sound_request.volume = self.volume
+        client.actionclient.wait_for_server(timeout=rospy.Duration(1.0))
         if lang is not None:
-            sound_goal.sound_request.arg2 = lang
-        sound_goal.sound_request.arg = speech_text
-        client.send_goal(sound_goal)
-        client.wait_for_result()
-        return client.get_result()
+            client.say(speech_text, voice=lang, replace=False)
+        else:
+            client.say(speech_text, replace=False)
+        client.actionclient.wait_for_result()
+        return client.actionclient.get_result()
 
     def _warn(self):
         if self.charge_level < self.threshold and not self.is_charging:

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/boot_sound.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/boot_sound.py
@@ -10,14 +10,12 @@ import rospkg
 
 from sound_play.libsoundplay import SoundClient
 import actionlib
-from sound_play.msg import SoundRequestAction
 
 if __name__ == "__main__":
     rospy.init_node("boot_sound")
-    sound = SoundClient()
-    time.sleep(1) # ???
-    ac = actionlib.SimpleActionClient('sound_play', SoundRequestAction)
-    ac.wait_for_server()
+    sound = SoundClient(sound_action='sound_play', blocking=True)
+    sound.actionclient.wait_for_server()
+
     if len(ni.ifaddresses('eth0')) > 2 :
         ip = ni.ifaddresses('eth0')[2][0]['addr']
     elif len(ni.ifaddresses('wlan0')) > 2 :
@@ -29,17 +27,10 @@ if __name__ == "__main__":
     rospack = rospkg.RosPack()
     wav_file = os.path.join(rospack.get_path("jsk_fetch_startup"),"data/boot_sound.wav")
     rospy.loginfo("Playing {}".format(wav_file))
-    sound.playWave(wav_file)
-    time.sleep(10) # make sure to topic is going out
+    sound.playWave(wav_file, replace=False)
 
     # notify ip address
     ip_text = "My internet address is {}".format(ip)
     rospy.loginfo(ip_text)
     ip_text = ip_text.replace('.', ', ')
-    sound.say(ip_text)
-    time.sleep(1) # make sure to topic is going out
-
-
-
-
-
+    sound.say(ip_text, replace=False)


### PR DESCRIPTION
This feature is useful when `sudo supervisorctl restart jsk-fetch-startup`.
boot_sound.py and battery_warning.py is called in order.

Use https://github.com/knorth55/audio_common/commit/0afc838d44e5e99d11de78f2315d5534ea732d18