### PR TITLE
Launch smach_notification_saver plugin by default in go-to-kitchen demo

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -7,6 +7,8 @@ timeout: 1200
 plugins:
   - name: service_notification_saver_plugin
     type: app_notification_saver/service_notification_saver
+  - name: smach_notification_saver_plugin
+    type: app_notification_saver/smach_notification_saver
   - name: head_camera_video_recorder_plugin
     type: app_recorder/audio_video_recorder_plugin
     launch_args:
@@ -138,6 +140,7 @@ plugins:
 plugin_order:
   start_plugin_order:
     - service_notification_saver_plugin
+    - smach_notification_saver_plugin
     - head_camera_video_recorder_plugin
     - object_detection_video_recorder_plugin
     - panorama_video_recorder_plugin
@@ -151,6 +154,7 @@ plugin_order:
     - mail_notifier_plugin
   stop_plugin_order:
     - service_notification_saver_plugin
+    - smach_notification_saver_plugin
     - head_camera_video_recorder_plugin
     - object_detection_video_recorder_plugin
     - panorama_video_recorder_plugin


### PR DESCRIPTION
Launch smach_notification_saver plugin by default in go-to-kitchen demo