### PR TITLE
Send email if battery is low

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/battery_warning.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/battery_warning.py
@@ -2,7 +2,10 @@
 # -*- coding: utf-8 -*-
 
 import actionlib
+import os
 import rospy
+import subprocess
+import yaml
 from sound_play.libsoundplay import SoundClient
 
 from power_msgs.msg import BatteryState
@@ -16,12 +19,21 @@ class BatteryWarning(object):
         self.threshold = rospy.get_param('~charge_level_threshold', 40.0)
         self.step = rospy.get_param('~charge_level_step', 10.0)
         self.volume = rospy.get_param('~volume', 1.0)
+        address_yaml = rospy.get_param(
+            '~address_yaml', "/var/lib/robot/battery_warning_address.yaml")
         self.subscriber = rospy.Subscriber(
             '/battery_state', BatteryState, self._cb, queue_size=1)
         self.timer = rospy.Timer(rospy.Duration(self.duration), self._timer_cb)
         self.charge_level = None
         self.prev_charge_level = None
         self.is_charging = False
+        self.send_mail = False
+        if os.path.exists(address_yaml):
+            self.send_mail = True
+            with open(address_yaml) as yaml_f:
+                yaml_addresses = yaml.load(yaml_f)
+                self.sender_address = yaml_addresses['sender_address']
+                self.receiver_address = yaml_addresses['receiver_address']
 
     def _speak(self, client, speech_text, lang=None):
         client.actionclient.wait_for_server(timeout=rospy.Duration(1.0))
@@ -32,15 +44,40 @@ class BatteryWarning(object):
         client.actionclient.wait_for_result()
         return client.actionclient.get_result()
 
+    def _send_mail(self, title, content, sender_address, receiver_address):
+        cmd = "LC_CTYPE=en_US.UTF-8 /bin/echo -e \"{}\"".format(content)
+        cmd += " | /usr/bin/mail -s \"{}\" -r {} {}".format(
+            title, sender_address, receiver_address)
+        exit_code = subprocess.call(cmd, shell=True)
+        rospy.loginfo('Title: {}'.format(title))
+        if exit_code > 0:
+            rospy.logerr(
+                'Failed to send e-mail:  {} -> {}'.format(
+                    sender_address, receiver_address))
+            rospy.logerr("You may need to do '$ sudo apt install mailutils'")
+        else:
+            rospy.loginfo(
+                'Succeeded to send e-mail: {} -> {}'.format(
+                    sender_address, receiver_address))
+
     def _warn(self):
         if self.charge_level < self.threshold and not self.is_charging:
             rospy.logerr("Low battery: only {}% remaining".format(self.charge_level))
-            sentence_jp = "バッテリー残り{}パーセントです。".format(self.charge_level)
-            sentence_jp += "もう限界ですので、僕をお家にかえしてください。"
-            sentence_en = "My battery is {} percent remaining.".format(self.charge_level)
-            sentence_en += "I want to go back home to charge my battery."
-            self._speak(self.client_jp, sentence_jp, 'jp')
-            self._speak(self.client_en, sentence_en)
+            sentence_battery_jp = "バッテリー残り{}パーセントです。".format(self.charge_level)
+            sentence_action_jp = "もう限界ですので、僕をお家にかえしてください。"
+            sentence_battery_en = "My battery is {} percent remaining.".format(
+                self.charge_level)
+            sentence_action_en = "I want to go back home to charge my battery."
+            self._speak(
+                self.client_jp, sentence_battery_jp + sentence_action_jp, 'jp')
+            self._speak(
+                self.client_en, sentence_battery_en + sentence_action_en)
+            if self.send_mail:
+                self._send_mail(
+                    'Fetch is low battery',
+                    sentence_battery_en + '\\n' + sentence_action_en + '\\n',
+                    self.sender_address,
+                    self.receiver_address)
             self.prev_charge_level = self.charge_level
         elif (self.prev_charge_level // self.step) > (self.charge_level // self.step):
             rospy.loginfo("Battery: {}% remaining".format(self.charge_level))


### PR DESCRIPTION
fetch sends email if battery is low.

address yaml file is like below:
```bash
$ cat /var/lib/robot/battery_warning_address.yaml
sender_address: sender@hoge.com
receiver_address: receiver@hoge.com
```

The output email is like below:
```
Fetch is low battery
===
My battery is 39 percent remaining.
I want to go back home to charge my battery.
```

I tested this PR by setting the receiver to my email address