### PR TITLE
[jsk_fetch_startup] add rotate_in_place to dock func

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -114,7 +114,7 @@
   (simple-dock))
 
 
-(defun undock (&key (rotate_in_place nil))
+(defun undock (&key (rotate-in-place nil))
   (unless *undock-action*
     (setq *undock-action*
           (instance ros::simple-action-client :init
@@ -124,7 +124,7 @@
     (return-from undock nil))
   (send *undock-action* :send-goal
         (instance fetch_auto_dock_msgs::UndockActionGoal :init
-                  :goal (instance fetch_auto_dock_msgs::UndockGoal :rotate_in_place rotate_in_place)))
+                  :goal (instance fetch_auto_dock_msgs::UndockGoal :rotate_in_place rotate-in-place)))
   (unless (send *undock-action* :wait-for-result :timeout 60)
     (ros::ros-error "No result returned from /undock action server")
     (return-from undock nil))
@@ -159,7 +159,7 @@
             (return-from go-to-spot-undock t))
           (if (equal battery-charging-state :charging)
             (progn
-              (setq undock-success (auto-undock :n-trial 3 :rotate_in_place undock-rotate)))
+              (setq undock-success (auto-undock :n-trial 3 :rotate-in-place undock-rotate)))
             (return-from go-to-spot-undock t))
           (if (not undock-success)
             (progn
@@ -186,14 +186,14 @@
     success))
 
 
-(defun auto-undock (&key (n-trial 1) (rotate_in_place nil))
+(defun auto-undock (&key (n-trial 1) (rotate-in-place nil))
   (let ((success nil))
     (unless (boundp '*ri*)
       (require :fetch-interface "package://fetcheus/fetch-interface.l")
       (fetch-init))
     (dotimes (i n-trial)
       (ros::ros-info "trying to do undock.")
-      (setq success (undock :rotate_in_place rotate_in_place))
+      (setq success (undock :rotate-in-place rotate-in-place))
       (when success (return-from auto-undock success)))
     (if (not success)
       (let ((enable-request (instance power_msgs::BreakerCommandRequest :init :enable t))

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -114,7 +114,7 @@
   (simple-dock))
 
 
-(defun undock ()
+(defun undock (&key (rotate_in_place nil))
   (unless *undock-action*
     (setq *undock-action*
           (instance ros::simple-action-client :init
@@ -123,7 +123,8 @@
     (ros::ros-error "/undock action server is not started")
     (return-from undock nil))
   (send *undock-action* :send-goal
-        (instance fetch_auto_dock_msgs::UndockActionGoal :init))
+        (instance fetch_auto_dock_msgs::UndockActionGoal :init
+                  :goal (instance fetch_auto_dock_msgs::UndockGoal :rotate_in_place rotate_in_place)))
   (unless (send *undock-action* :wait-for-result :timeout 60)
     (ros::ros-error "No result returned from /undock action server")
     (return-from undock nil))
@@ -158,10 +159,7 @@
             (return-from go-to-spot-undock t))
           (if (equal battery-charging-state :charging)
             (progn
-              (setq undock-success (auto-undock :n-trial 3))
-              ;; rotate after undock
-              (if (and undock-success undock-rotate)
-                (send *ri* :go-pos-unsafe 0 0 180)))
+              (setq undock-success (auto-undock :n-trial 3 :rotate_in_place undock-rotate)))
             (return-from go-to-spot-undock t))
           (if (not undock-success)
             (progn
@@ -188,14 +186,14 @@
     success))
 
 
-(defun auto-undock (&key (n-trial 1))
+(defun auto-undock (&key (n-trial 1) (rotate_in_place nil))
   (let ((success nil))
     (unless (boundp '*ri*)
       (require :fetch-interface "package://fetcheus/fetch-interface.l")
       (fetch-init))
     (dotimes (i n-trial)
       (ros::ros-info "trying to do undock.")
-      (setq success (undock))
+      (setq success (undock :rotate_in_place rotate_in_place))
       (when success (return-from auto-undock success)))
     (if (not success)
       (let ((enable-request (instance power_msgs::BreakerCommandRequest :init :enable t))


### PR DESCRIPTION
Use 180 degrees rotations function of undock action instead of manually executing go-pos-unsafe