### PR TITLE
Use :relative-pos and :relative-rot for (go-to-spot)

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/go-to-kitchen-with-mail-notify.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/go-to-kitchen-with-mail-notify.l
@@ -34,7 +34,7 @@
 (defun go-to-kitchen ()
   ;; call k-okada
   (send *ri* :speak-jp "キッチンに向かうよ")
-  (go-to-spot "/eng2/7f/room73B2-sink-front1" (make-coords :pos #f(100 -1000 0)))
+  (go-to-spot "/eng2/7f/room73B2-sink-front1" :relative-pos #f(100 -1000 0))
   (unix:sleep 1)
   (send *ri* :speak-jp "キッチンについたよ" :wait t)
   (send *fetch* :head :neck-y :joint-angle -30)

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/go-to-kitchen.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/go-to-kitchen.l
@@ -4,7 +4,7 @@
 (load "package://jsk_fetch_startup/euslisp/navigation-utils.l")
 
 
-(defun main (&key (tweet t) (n-dock-trial 3) (n-kitchen-trial 3) (control-switchbot :api))
+(defun main (&key (tweet t) (n-dock-trial 3) (n-kitchen-trial 3) (n-trashcan-trial 3) (control-switchbot :api))
   (when (not (boundp '*sm*))
     (go-to-kitchen-state-machine))
   (let ((result-state
@@ -15,6 +15,7 @@
                                      (control-switchbot . ,control-switchbot)
                                      (initial-light-on . nil)
                                      (success-go-to-kitchen . nil)
+                                     (success-go-to-trashcan . nil)
                                      (success-auto-dock . nil))
                               :hz 2.0)))
     (send result-state :name)))

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/go-to-kitchen.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/go-to-kitchen.l
@@ -10,6 +10,7 @@
   (let ((result-state
           (exec-state-machine *sm* `((tweet . ,tweet)
                                      (n-kitchen-trial . ,n-kitchen-trial)
+                                     (n-trashcan-trial . ,n-trashcan-trial)
                                      (n-dock-trial . ,n-dock-trial)
                                      (control-switchbot . ,control-switchbot)
                                      (initial-light-on . nil)

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -359,7 +359,7 @@
     (dotimes (i n-trial)
       (setq success-move-to-trashcan-front
             (go-to-spot "/eng2/7f/room73B2-microwave-front"
-                        (make-coords :pos offset)))
+                        (make-coords :pos offset :rpy (float-vector -pi/2 0 0))))
       (when success-move-to-trashcan-front (return)))
     success-move-to-trashcan-front))
 

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -172,7 +172,7 @@
     (when relative-pos
       (setq goal-pose (send goal-pose :translate relative-pos :world)))
     (when relative-rot
-      (setq goal-pose (send goal-pose :rotate relative-rot :local)))
+      (setq goal-pose (send goal-pose :rotate relative-rot :z :local)))
     (send *ri* :move-to goal-pose :frame-id frame-id)))
 
 
@@ -359,7 +359,7 @@
     (dotimes (i n-trial)
       (setq success-move-to-trashcan-front
             (go-to-spot "/eng2/7f/room73B2-microwave-front"
-                        (make-coords :pos offset :rpy (float-vector -pi/2 0 0))))
+                        :relative-pos offset :relative-rot -pi/2))
       (when success-move-to-trashcan-front (return)))
     success-move-to-trashcan-front))
 

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -282,6 +282,13 @@
   (ros::ros-error "failed going to the kitchen.")
   (send *ri* :speak-jp "キッチンのコンロの前に行くのに失敗しました。" :wait t))
 
+(defun report-move-to-trashcan-front ()
+  (ros::ros-info "arrived at the trash can")
+  (send *ri* :speak-jp "ゴミ箱の前につきました。" :wait t))
+
+(defun report-move-to-trashcan-front-failure ()
+  (ros::ros-error "failed going to the trash can front")
+  (send *ri* :speak-jp "ゴミ箱の前に行くのに失敗しました。" :wait t))
 
 (defun report-start-go-to-kitchen ()
   (ros::ros-info "start going to the kitchen.")
@@ -336,6 +343,27 @@
       (when success-move-to-sink-front (return)))
     success-move-to-sink-front))
 
+(defun inspect-trashcan (&key (tweet t))
+  (report-move-to-trashcan-front)
+  (send *fetch* :head :neck-y :joint-angle 70)
+  (send *ri* :angle-vector-raw (send *fetch* :angle-vector) 3000 :head-controller)
+  (send *ri* :wait-interpolation)
+  (if tweet
+      (tweet-string "I took a photo of 73B2 trash cans." :warning-time 3
+                    :with-image "/edgetpu_object_detector/output/image" :speak t)
+      (notify-recognition :location "trash cans"))
+    (progn
+      (notify-recognition :location "trash cans"))))
+
+(defun move-to-trashcan-front (&key (n-trial 1) (offset #f(0 0 0)))
+  (let ((success-move-to-trashcan-front nil))
+    (dotimes (i n-trial)
+      (setq success-move-to-trashcan-front
+            (go-to-spot "/eng2/7f/room73B2-trashbox-front"
+                        (make-coords :pos offset) :undock-rotate t))
+      (when success-move-to-trashcan-front (return)))
+    success-move-to-trashcan-front))
+
 
 (defun go-to-kitchen (&key (tweet t) (n-dock-trial 1) (n-kitchen-trial 1)
                            (control-switchbot :api))
@@ -347,6 +375,7 @@
   ;; Check if the lights are on in the room
   (let ((initial-light-on (get-light-on))
         (success-go-to-kitchen nil)
+        (success-go-to-trashcan nil)
         (success-auto-dock nil)
         (success-battery-charging nil))
     (store-params)
@@ -364,6 +393,12 @@
     (if success-go-to-kitchen
       (inspect-kitchen :tweet tweet)
       (report-move-to-sink-front-failure))
+    ;; go to kitchen trash can
+    (setq success-go-to-trashcan (move-to-trashcan-front :n-trial n-trashcan-trial))
+    ;; report result to go to trash can
+    (if success-go-to-trashcan
+      (inspect-trashcan :tweet tweet)
+      (report-move-to-trashcan-front-failure))
     ;; go back from dock
     (report-auto-dock)
     (setq success-auto-dock (auto-dock :n-trial n-dock-trial :clear-costmap nil))
@@ -387,8 +422,13 @@
             (:room-light-on -> :move-to-sink-front)
             (:move-to-sink-front -> :inspect-kitchen)
             (:move-to-sink-front !-> :report-move-to-sink-front-failure)
-            (:inspect-kitchen -> :auto-dock)
-            (:report-move-to-sink-front-failure -> :auto-dock)
+            ;;(:inspect-kitchen -> :auto-dock)
+            ;;(:report-move-to-sink-front-failure -> :auto-dock)
+            (:inspect-kitchen -> :move-to-trashcan-front)
+            (:move-to-trashcan-front -> :inspect-trashcan)
+            (:move-to-trashcan-front !-> :report-move-to-trashcan-front-failure)
+            (:inspect-trashcan -> :auto-dock)
+            (:report-move-to-trashcan-front-failure -> :auto-dock)
             (:auto-dock -> :room-light-off)
             (:room-light-off -> :finish)
             (:finish -> t)
@@ -433,6 +473,20 @@
             (:report-move-to-sink-front-failure
               '(lambda (userdata)
                  (report-move-to-sink-front-failure)
+                 t))
+            (:move-to-trashcan-front
+              '(lambda (userdata)
+                 (let* ((n-trial (cdr (assoc 'n-trashcan-trial userdata)))
+                        (success (move-to-trashcan-front :n-trial n-trial)))
+                   (setf (cdr (assoc 'success-go-to-trashcan userdata)) success)
+                   success)))
+            (:inspect-trashcan
+              '(lambda (userdata)
+                 (inspect-trashcan :tweet (cdr (assoc 'tweet userdata)))
+                 t))
+            (:report-move-to-trashcan-front-failure
+              '(lambda (userdata)
+                 (report-move-to-trashcan-front-failure)
                  t))
             (:auto-dock
               '(lambda (userdata)

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -140,8 +140,7 @@
      (if is-charging :charging :discharging)))
 
 
-(defun go-to-spot (name &optional (relative-coords (make-coords))
-                        &key (undock-rotate nil) (clear-costmap t))
+(defun go-to-spot (name &key (relative-pos nil) (relative-rot nil) (undock-rotate nil) (clear-costmap t))
   ;; undock if fetch is docking
   (unless (boundp '*ri*)
     (require :fetch-interface "package://fetcheus/fetch-interface.l")
@@ -170,15 +169,18 @@
   (let* ((ret (get-spot-coords name))
          (goal-pose (car ret))
          (frame-id (cdr ret)))
-    (when relative-coords
-      (setq goal-pose (send goal-pose :transform relative-coords :world)))
+    (when relative-pos
+      (setq goal-pose (send goal-pose :translate relative-pos :world)))
+    (when relative-rot
+      (setq goal-pose (send goal-pose :rotate relative-rot :local)))
     (send *ri* :move-to goal-pose :frame-id frame-id)))
 
 
 (defun auto-dock (&key (n-trial 1) (clear-costmap t))
   (let ((success nil))
     (dotimes (i n-trial)
-      (when (go-to-spot *dock-spot* (make-coords :pos #f(-800 0 0))
+      (when (go-to-spot *dock-spot*
+                        :relative-pos #f(-800 0 0)
                         :clear-costmap clear-costmap)
         (ros::ros-info "arrived at the dock.")
         (setq success (dock))
@@ -330,7 +332,7 @@
     (dotimes (i n-trial)
       (setq success-move-to-sink-front
             (go-to-spot "/eng2/7f/room73B2-sink-front0"
-                        (make-coords :pos offset) :undock-rotate t))
+                        :relative-pos offset :undock-rotate t))
       (when success-move-to-sink-front (return)))
     success-move-to-sink-front))
 

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -343,7 +343,7 @@
 
 (defun inspect-trashcan (&key (tweet t))
   (report-move-to-trashcan-front)
-  (send *fetch* :head :neck-p :joint-angle 25)
+  (send *fetch* :head :neck-p :joint-angle 40)
   (send *ri* :angle-vector-raw (send *fetch* :angle-vector) 3000 :head-controller)
   (send *ri* :wait-interpolation)
   (if tweet

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -327,11 +327,9 @@
       ;; sink
       (tweet-string "I took a photo at 73B2 Kitchen sink." :warning-time 3
                     :with-image "/edgetpu_object_detector/output/image" :speak t)
-      (notify-recognition :location "kitchen sink")
-      (send *ri* :go-pos-unsafe 0 0 135))
+      (notify-recognition :location "kitchen sink"))
     (progn
-      (notify-recognition :location "kitchen")
-      (send *ri* :go-pos-unsafe 0 0 90))))
+      (notify-recognition :location "kitchen"))))
 
 
 (defun move-to-sink-front (&key (n-trial 1) (offset #f(400 -500 0)))
@@ -345,22 +343,23 @@
 
 (defun inspect-trashcan (&key (tweet t))
   (report-move-to-trashcan-front)
-  (send *fetch* :head :neck-y :joint-angle 70)
+  (send *fetch* :head :neck-p :joint-angle 25)
   (send *ri* :angle-vector-raw (send *fetch* :angle-vector) 3000 :head-controller)
   (send *ri* :wait-interpolation)
   (if tweet
-      (tweet-string "I took a photo of 73B2 trash cans." :warning-time 3
-                    :with-image "/edgetpu_object_detector/output/image" :speak t)
-      (notify-recognition :location "trash cans"))
+      (progn
+	(tweet-string "I took a photo of 73B2 trash cans." :warning-time 3
+		      :with-image "/edgetpu_object_detector/output/image" :speak t)
+	(notify-recognition :location "trash cans"))
     (progn
       (notify-recognition :location "trash cans"))))
 
-(defun move-to-trashcan-front (&key (n-trial 1) (offset #f(0 0 0)))
+(defun move-to-trashcan-front (&key (n-trial 1) (offset #f(-300 -300 0)))
   (let ((success-move-to-trashcan-front nil))
     (dotimes (i n-trial)
       (setq success-move-to-trashcan-front
-            (go-to-spot "/eng2/7f/room73B2-trashbox-front"
-                        (make-coords :pos offset) :undock-rotate t))
+            (go-to-spot "/eng2/7f/room73B2-microwave-front"
+                        (make-coords :pos offset)))
       (when success-move-to-trashcan-front (return)))
     success-move-to-trashcan-front))
 


### PR DESCRIPTION
I use `:relative-pos` and `:relative-rot` for `(go-to-spot)`.
This is because
- we want to move target-spot's pos in :world(/map) frame
- we want to move target-spot's rot in local(/base_link) frame

@tkmtnt7000
Could you please use this commit with your trashcan demo?
If this commit is fine, please tell me. I will merge this PR.