### PR TITLE
send /move_base/cancel when go-to-kitchen stopped

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -146,6 +146,7 @@ plugins:
           type: GoalID
 plugin_order:
   start_plugin_order:
+    - move_base_cancel_plugin
     - service_notification_saver_plugin
     - smach_notification_saver_plugin
     - head_camera_video_recorder_plugin
@@ -159,8 +160,8 @@ plugin_order:
     - tweet_notifier_plugin
     - speech_notifier_plugin
     - mail_notifier_plugin
-    - move_base_cancel_plugin
   stop_plugin_order:
+    - move_base_cancel_plugin
     - service_notification_saver_plugin
     - smach_notification_saver_plugin
     - head_camera_video_recorder_plugin
@@ -174,4 +175,3 @@ plugin_order:
     - tweet_notifier_plugin
     - speech_notifier_plugin
     - mail_notifier_plugin
-    - move_base_cancel_plugin

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -137,6 +137,13 @@ plugins:
       mail_title: Fetch kitchen patrol demo
       use_timestamp_title: true
     plugin_arg_yaml: /var/lib/robot/fetch_mail_notifier_plugin.yaml
+  - name: move_base_cancel_plugin
+    type: app_publisher/rostopic_publisher_plugin
+    plugin_args:
+      stop_topics:
+        - name: "/move_base/cancel"
+          pkg: actionlib_msgs
+          type: GoalID
 plugin_order:
   start_plugin_order:
     - service_notification_saver_plugin
@@ -152,6 +159,7 @@ plugin_order:
     - tweet_notifier_plugin
     - speech_notifier_plugin
     - mail_notifier_plugin
+    - move_base_cancel_plugin
   stop_plugin_order:
     - service_notification_saver_plugin
     - smach_notification_saver_plugin
@@ -166,3 +174,4 @@ plugin_order:
     - tweet_notifier_plugin
     - speech_notifier_plugin
     - mail_notifier_plugin
+    - move_base_cancel_plugin


### PR DESCRIPTION
Send `/move_base/cancel` when `go-to-kitchen` app is stopped.

Sometimes, `move_base` continues to work though `go-to-kitchen` is stopped.

Depends on https://github.com/knorth55/app_manager_utils/pull/26