### PR TITLE
[Fetch] Update moving to trashcan-front in kitchen demo

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -362,13 +362,15 @@
     (progn
       (notify-recognition :location "trash cans"))))
 
-(defun move-to-trashcan-front (&key (n-trial 1) (offset #f(-400 -300 0)))
+(defun move-to-trashcan-front (&key (n-trial 1) (offset #f(400 -500 0)))
   (let ((success-move-to-trashcan-front nil))
     (dotimes (i n-trial)
       (setq success-move-to-trashcan-front
-            (go-to-spot "/eng2/7f/room73B2-microwave-front"
+            (go-to-spot "/eng2/7f/room73B2-sink-front0"
                         :relative-pos offset :relative-rot -pi/2))
       (when success-move-to-trashcan-front (return)))
+    (send *ri* :go-pos-unsafe 1.3 0 0)
+    (send *ri* :go-pos-unsafe 0 0 -80) ;; face the front against the trash can
     success-move-to-trashcan-front))
 
 


### PR DESCRIPTION
These days, kithen patrol demo sometimes takes over ten minutes, so I update kitchen-demo to move from sink-front to trashcan-front faster than before.
I use `:go-pos-unsafe` when moving to trashcan-front.
Cc:@708yamaguchi