### PR TITLE
Use co2 topic in go-to-kitchen demo

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -74,6 +74,11 @@
     local-name: ros-drivers/audio_common
     uri: https://github.com/ros-drivers/audio_common.git
     version: master
+# Remove after https://github.com/ros-drivers/rosserial/pull/570 is merged and released
+- git:
+    local-name: ros-drivers/rosserial
+    uri: https://github.com/708yamaguchi/rosserial.git
+    version: fetch15
 - git:
     local-name: ros-perception/slam_gmapping
     uri: https://github.com/ros-perception/slam_gmapping.git

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
@@ -7,6 +7,15 @@
     <param name="score_thresh" type="double" value="0.60" /> <!-- default: 0.6 -->
   </node>
 
+  <!-- Use m5stack_ros -->
+  <!-- See https://github.com/jsk-ros-pkg/jsk_3rdparty/pull/289 -->
+  <node name="rosserial_m5stack" pkg="rosserial_python" type="serial_node.py">
+    <rosparam>
+      port: /dev/rfcomm0 <!-- See /var/lib/robot/rfcomm_devices.yaml -->
+      baud: 115200
+    </rosparam>
+  </node>
+
   <node name="$(anon rviz)" pkg="rviz" type="rviz"
         args="-d $(find jsk_fetch_startup)/config/jsk_startup_record.rviz">
     <env name="DISPLAY" value=":0" />

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -315,6 +315,17 @@
                   location
                   (format nil "~A is found" label-names)))))
 
+(defun notify-co2 (&key (location "kitchen"))
+  (let* ((msg (one-shot-subscribe "/eco2" std_msgs::UInt16
+                                  :timeout 3000)))
+    (when msg
+      (ros::ros-info
+       (format nil "Notify app that co2 concentration is measured."))
+      (notify-app "CO2 concentration"
+                  (ros::time-now)
+                  location
+                  (format nil "CO2 concentration is ~A ppm" (send msg :data))))))
+
 (defun inspect-kitchen (&key (tweet t))
   (report-move-to-sink-front-success)
   (if tweet
@@ -323,6 +334,7 @@
       (tweet-string "I took a photo at 73B2 Kitchen stove." :warning-time 3
                     :with-image "/edgetpu_object_detector/output/image" :speak t)
       (notify-recognition :location "kitchen stove")
+      (notify-co2 :location "kitchen stove")
       (send *ri* :go-pos-unsafe 0 0 -45)
       ;; sink
       (tweet-string "I took a photo at 73B2 Kitchen sink." :warning-time 3

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-rfcomm-bind.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-rfcomm-bind.conf
@@ -1,0 +1,12 @@
+[program:jsk-rfcomm-bind]
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && roslaunch jsk_robot_startup rfcomm_bind.launch --wait"
+
+stopsignal=TERM
+directory=/home/fetch/ros/melodic
+autostart=true
+autorestart=false
+stdout_logfile=/var/log/ros/jsk-rfcomm-bind.log
+stderr_logfile=/var/log/ros/jsk-rfcomm-bind.log
+user=root
+environment=ROSCONSOLE_FORMAT="[${severity}] [${time}] [${node}:${logger}]: ${message}",PYTHONUNBUFFERED=1
+priority=200

--- a/jsk_fetch_robot/jsk_fetch_startup/tmuxinator_yaml/log.yml
+++ b/jsk_fetch_robot/jsk_fetch_startup/tmuxinator_yaml/log.yml
@@ -45,3 +45,4 @@ windows:
   - jsk-dialog: tail -f -n 1000 /var/log/ros/jsk-dialog.log
   - jsk-gdrive: tail -f -n 1000 /var/log/ros/jsk-gdrive.log
   - jsk-dstat: tail -f -n 1000 /var/log/ros/jsk-dstat.log
+  - jsk-rfcomm-bind: tail -f -n 1000 /var/log/ros/jsk-rfcomm-bind.log


### PR DESCRIPTION
- Automatically bind rfcomm devices when booting fetch
- Launch m5stack program to publish eco2 topic in go-to-kitchen demo