### PR TITLE
[jsk_fetch_startup] Use catkin build -v in update_workspace.sh

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/update_workspace.sh
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/update_workspace.sh
@@ -16,7 +16,7 @@ cd $HOME/ros/melodic
 catkin clean aques_talk collada_urdf_jsk_patch -y
 catkin init
 catkin config -DCMAKE_BUILD_TYPE=Release
-catkin build
+catkin build -v
 CATKIN_BUILD_RESULT=$?
 # Send mail
 MAIL_BODY=""


### PR DESCRIPTION
Related to #158 
This PR updates update_workspace.sh to display the output of `catkin build` in detail.