### PR TITLE
[jsk_fetch_startup] Suppress catkin build log 

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/update_workspace.sh
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/update_workspace.sh
@@ -27,15 +27,17 @@ if [ $CATKIN_BUILD_RESULT -ne 0 ]; then
     MAIL_BODY=$MAIL_BODY"Please catkin build workspace manually."
 fi
 set +x
-} > $LOGFILE 2>&1
-rostopic pub -1 /email jsk_robot_startup/Email "header:
-  seq: 0
-  stamp: {secs: 0, nsecs: 0}
-  frame_id: ''
-subject: 'Daily workspace update fails'
-body: '$MAIL_BODY'
-sender_address: '$(hostname)@jsk.imi.i.u-tokyo.ac.jp'
-receiver_address: 'fetch@jsk.imi.i.u-tokyo.ac.jp'
-smtp_server: ''
-smtp_port: ''
-attached_files: ['$LOGFILE']"
+} 2>&1 | tee $LOGFILE
+if [ -n "$MAIL_BODY" ]; then
+    rostopic pub -1 /email jsk_robot_startup/Email "header:
+      seq: 0
+      stamp: {secs: 0, nsecs: 0}
+      frame_id: ''
+    subject: 'Daily workspace update fails'
+    body: '$MAIL_BODY'
+    sender_address: '$(hostname)@jsk.imi.i.u-tokyo.ac.jp'
+    receiver_address: 'fetch@jsk.imi.i.u-tokyo.ac.jp'
+    smtp_server: ''
+    smtp_port: ''
+    attached_files: ['$LOGFILE']"
+fi

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/update_workspace.sh
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/update_workspace.sh
@@ -16,7 +16,7 @@ cd $HOME/ros/melodic
 catkin clean aques_talk collada_urdf_jsk_patch -y
 catkin init
 catkin config -DCMAKE_BUILD_TYPE=Release
-catkin build -v
+catkin build
 CATKIN_BUILD_RESULT=$?
 # Send mail
 MAIL_BODY=""

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/update_workspace.sh
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/update_workspace.sh
@@ -27,17 +27,17 @@ if [ $CATKIN_BUILD_RESULT -ne 0 ]; then
     MAIL_BODY=$MAIL_BODY"Please catkin build workspace manually."
 fi
 set +x
-} 2>&1 | tee $LOGFILE
+} > $LOGFILE 2>&1
 if [ -n "$MAIL_BODY" ]; then
-    rostopic pub -1 /email jsk_robot_startup/Email "header:
-      seq: 0
-      stamp: {secs: 0, nsecs: 0}
-      frame_id: ''
-    subject: 'Daily workspace update fails'
-    body: '$MAIL_BODY'
-    sender_address: '$(hostname)@jsk.imi.i.u-tokyo.ac.jp'
-    receiver_address: 'fetch@jsk.imi.i.u-tokyo.ac.jp'
-    smtp_server: ''
-    smtp_port: ''
-    attached_files: ['$LOGFILE']"
+   rostopic pub -1 /email jsk_robot_startup/Email "header:
+  seq: 0
+  stamp: {secs: 0, nsecs: 0}
+  frame_id: ''
+subject: 'Daily workspace update fails'
+body: '$MAIL_BODY'
+sender_address: '$(hostname)@jsk.imi.i.u-tokyo.ac.jp'
+receiver_address: 'fetch@jsk.imi.i.u-tokyo.ac.jp'
+smtp_server: ''
+smtp_port: ''
+attached_files: ['$LOGFILE']"
 fi


### PR DESCRIPTION
This PR supports suppressing catkin build log, displaying output of update_workspace.sh and sending mail only when updating workspace fails.
Cc:@708yamaguchi