### PR TITLE
[jsk_fetch_startup] Add take-photo function to navigation-utils.l

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -110,6 +110,7 @@ plugins:
         - /tmp/go_to_kitchen_rviz.avi
         - /tmp/go_to_kitchen_audio.wav
         - /tmp/go_to_kitchen_rosbag.bag
+        - /tmp/trashcan_inside.jpg
       upload_file_titles:
         - go_to_kitchen_result.yaml
         - go_to_kitchen_head_camera.avi
@@ -118,6 +119,7 @@ plugins:
         - go_to_kitchen_rviz.avi
         - go_to_kitchen_audio.wav
         - go_to_kitchen_rosbag.bag
+        - trashcan_inside.jpg
       upload_parents_path: fetch_go_to_kitchen
       upload_server_name: /gdrive_server
   - name: tweet_notifier_plugin

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -9,6 +9,7 @@
 (ros::load-ros-manifest "jsk_robot_startup")
 (ros::load-ros-manifest "jsk_recognition_msgs")
 (ros::load-ros-manifest "power_msgs")
+(ros::load-ros-manifest "sensor_msgs")
 
 (defparameter *dock-action* nil)
 (defparameter *undock-action* nil)
@@ -304,6 +305,18 @@
   (ros::ros-info "room light is off.")
   (send *ri* :speak-jp "電気が消えています。" :wait t))
 
+(defun take-photo (file-name
+                   &optional (image-topic "/edgetpu_object_detector/output/image"))
+  (let ((img nil))
+    (unix::system (format nil "rm -f /tmp/~A" file-name))
+    (setq img (one-shot-subscribe image-topic sensor_msgs::Image :timeout 1000))
+    (if img
+        (progn
+          (write-image-file (format nil "/tmp/~A" file-name)
+                            (ros::sensor_msgs/Image->image img))
+          (ros::ros-info "taking a photo ~A" file-name))
+        (ros::ros-error "fail saving image"))))
+
 (defun notify-recognition (&key (location "kitchen"))
   (let* ((msg (one-shot-subscribe "/edgetpu_object_detector/output/class"
                                   jsk_recognition_msgs::ClassificationResult))
@@ -369,6 +382,7 @@
         (send *ri* :wait-interpolation)
         (tweet-string "I took a photo of 73B2 trash can inside." :warning-time 3
                       :with-image "/edgetpu_object_detector/output/image" :speak t)
+        (take-photo "trashcan_inside.jpg")
         (notify-recognition :location "trash cans inside")
         (send *ri* :go-pos-unsafe -0.2 0 0))
     (progn


### PR DESCRIPTION
This PR enables Fetch to attach pictures to kitchen-patrol-demo result email.
A photo of the inside of the trash can is now sent as an attachment to the email.
![Screenshot from 2021-12-21 20-59-32](https://user-images.githubusercontent.com/67531577/146928961-568bc643-2661-4e52-9fbd-3443e247176e.png)

