### PR TITLE
[jsk_fetch_startup] Update charge level warning to prevent battery degradation

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -34,7 +34,7 @@
         respawn="true" output="screen" if="$(arg battery_warning)">
     <rosparam>
       duration: 180
-      charge_level_threshold: 40.0
+      charge_level_threshold: 80.0
       charge_level_step: 10.0
       volume: 1.0
     </rosparam>

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/battery_warning.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/battery_warning.py
@@ -16,7 +16,7 @@ class BatteryWarning(object):
         self.client_en = SoundClient(sound_action='/sound_play', blocking=True)
         self.client_jp = SoundClient(sound_action='/robotsound_jp', blocking=True)
         self.duration = rospy.get_param('~duration', 180.0)
-        self.threshold = rospy.get_param('~charge_level_threshold', 40.0)
+        self.threshold = rospy.get_param('~charge_level_threshold', 80.0)
         self.step = rospy.get_param('~charge_level_step', 10.0)
         self.volume = rospy.get_param('~volume', 1.0)
         address_yaml = rospy.get_param(


### PR DESCRIPTION
This PR updates charge level warning to prevent battery degradation.
Especially when the robot is left unattended.
cc:@708yamaguchi