### PR TITLE
[jsk_fetch_startup] Add auto-dock on move-to-sink-front failure to protect battery

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -305,6 +305,12 @@
   (ros::ros-info "room light is off.")
   (send *ri* :speak-jp "電気が消えています。" :wait t))
 
+
+(defun report-auto-dock-failure ()
+  (ros::ros-error "failed auto-docking")
+  (send *ri* :speak-jp "ドックに失敗しました。" :wait t))
+
+
 (defun take-photo (file-name
                    &optional (image-topic "/edgetpu_object_detector/output/image"))
   (let ((img nil))
@@ -485,6 +491,8 @@
             (:inspect-trashcan -> :auto-dock)
             (:report-move-to-trashcan-front-failure -> :auto-dock)
             (:auto-dock -> :room-light-off)
+            (:auto-dock !-> :auto-dock-failure)
+            (:auto-dock-failure -> :room-light-off)
             (:room-light-off -> :finish)
             (:finish -> t)
             (:finish !-> nil))
@@ -550,6 +558,10 @@
                         (success (auto-dock :n-trial n-trial :clear-costmap nil)))
                    (setf (cdr (assoc 'success-auto-dock userdata)) success)
                    success)))
+            (:auto-dock-failure
+              '(lambda (userdata)
+                 (report-auto-dock-failure)
+                 t))
             (:room-light-off
               '(lambda (userdata)
                  (let ((success-auto-dock (cdr (assoc 'success-auto-dock userdata)))

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -478,7 +478,7 @@
             (:move-to-sink-front -> :inspect-kitchen)
             (:move-to-sink-front !-> :report-move-to-sink-front-failure)
             ;;(:inspect-kitchen -> :auto-dock)
-            ;;(:report-move-to-sink-front-failure -> :auto-dock)
+            (:report-move-to-sink-front-failure -> :auto-dock)
             (:inspect-kitchen -> :move-to-trashcan-front)
             (:move-to-trashcan-front -> :inspect-trashcan)
             (:move-to-trashcan-front !-> :report-move-to-trashcan-front-failure)


### PR DESCRIPTION
This PR updates go-to-kitchen demo **to protect battery** by leaving the robot unattended in case of demo failure.

1. Shift `:auto-dock` state when move-to-sink-front fails
~2. Execute `Poweroff` when auto-dock fails~

~I don't know how 2 (f976bcb4e89ef561b273efdc3ff03017dcdf617b) will behave in practice, so I need to try it out.~

cc: @708yamaguchi 