### PR TITLE
[jsk_fetch_startup] Do not stop auto-dock to cause timeout and shutdown in go-to-kitchen

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -153,7 +153,9 @@ plugins:
         - name: "/shutdown"
           pkg: std_msgs
           type: Empty
-          cond: timeout
+          cond:
+            - timeout
+            - failure
 plugin_order:
   start_plugin_order:
     - move_base_cancel_plugin

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/go-to-kitchen.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/go-to-kitchen.l
@@ -4,7 +4,7 @@
 (load "package://jsk_fetch_startup/euslisp/navigation-utils.l")
 
 
-(defun main (&key (tweet t) (n-dock-trial 3) (n-kitchen-trial 3) (n-trashcan-trial 3) (control-switchbot :api))
+(defun main (&key (tweet t) (n-dock-trial 99999) (n-kitchen-trial 3) (n-trashcan-trial 3) (control-switchbot :api))
   (when (not (boundp '*sm*))
     (go-to-kitchen-state-machine))
   (let ((result-state

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/go-to-kitchen.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/go-to-kitchen.l
@@ -4,7 +4,7 @@
 (load "package://jsk_fetch_startup/euslisp/navigation-utils.l")
 
 
-(defun main (&key (tweet t) (n-dock-trial 99999) (n-kitchen-trial 3) (n-trashcan-trial 3) (control-switchbot :api))
+(defun main (&key (tweet t) (n-dock-trial 3) (n-kitchen-trial 3) (n-trashcan-trial 3) (control-switchbot :api))
   (when (not (boundp '*sm*))
     (go-to-kitchen-state-machine))
   (let ((result-state


### PR DESCRIPTION
Today fetch is stucked during AUTO-DOCK after INSPECT-TRASHCAN.

```
Following smach is reported.
 - At 2021-12-25T09:00:22, Active states is REPORT-START-GO-TO-KITCHEN.
 - At 2021-12-25T09:00:25, Active states is GET-LIGHT-ON.
 - At 2021-12-25T09:00:26, Active states is ROOM-LIGHT-ON.
 - At 2021-12-25T09:00:32, Active states is MOVE-TO-SINK-FRONT.
 - At 2021-12-25T09:01:07, Active states is INSPECT-KITCHEN.
 - At 2021-12-25T09:01:26, Active states is MOVE-TO-TRASHCAN-FRONT.
 - At 2021-12-25T09:01:35, Active states is INSPECT-TRASHCAN.
```

From a battery protection point of view, we want fetch to shutdown in this situation.

So, I increased the number of trials for auto-dock and made it timeout if AUTO-DOCK stucked.
When go-to-kitchen times out, fetch will shut down.

@tkmtnt7000

If you have any good idea, please teach me.