### PR TITLE
[WIP] [jsk_fetch_startup] Fix the process for no recognition result of trashcan occupancy

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -349,9 +349,10 @@
   (let* ((msg (one-shot-subscribe "/trashbin_occupancy_detector/trashbin/occupancy"
                                   jsk_recognition_msgs::BoundingBoxArray
                                   :timeout 3000))
-         (occupancy (send (elt (send msg :boxes) 0) :value))
+         (occupancy nil)
          (notify-text nil))
-    (when occupancy
+    (when msg
+      (setq occcupancy (send (elt (send msg :boxes) 0) :value))
       (ros::ros-info
        (format nil "Notify app that the occupancy of trash can is measured."))
       (if (> occupancy 1.0)

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -355,7 +355,7 @@
                                       "Trashcan is not full."))))
     (when occupancy
       (ros::ros-info
-       (format nil "Notify app that the occupancy of trash can is measured."))
+       (format nil "Notify app that the occupancy of trash can is measured. ~A." occupancy))
       (notify-app "trashcan occupancy"
                   (ros::time-now)
                   location

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -349,15 +349,13 @@
   (let* ((msg (one-shot-subscribe "/trashbin_occupancy_detector/trashbin/occupancy"
                                   jsk_recognition_msgs::BoundingBoxArray
                                   :timeout 3000))
-         (occupancy nil)
-         (notify-text nil))
-    (when msg
-      (setq occcupancy (send (elt (send msg :boxes) 0) :value))
+         (occupancy (if msg (send (elt (send msg :boxes) 0) :value)))
+         (notify-text (if occupancy (if (> occupancy 1.0)
+                                      "Trashcan is full."
+                                      "Trashcan is not full."))))
+    (when occupancy
       (ros::ros-info
        (format nil "Notify app that the occupancy of trash can is measured."))
-      (if (> occupancy 1.0)
-        (setq notify-text "Trashcan is full.")
-        (setq notify-text "Trashcan is not full."))
       (notify-app "trashcan occupancy"
                   (ros::time-now)
                   location


### PR DESCRIPTION
`kitchen-demo` on Decenber 25th failed (stucked in `INSPECT-TRASHCAN` state) because the process for no recognition result of trashcan occupancy was not well written. 
Error log: https://gist.github.com/tkmtnt7000/8052f67631c421c6925c8ebbb4fcb892
This PR fixes it.

I'm very very sorry, but I haven't been able to check it on the real robot, so this PR is still WIP.