### PR TITLE
[jsk_fetch_startup] catkin clean libcmt before build in daily update_workspace.sh

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/update_workspace.sh
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/update_workspace.sh
@@ -13,7 +13,7 @@ wstool foreach --git 'git stash'
 wstool update --delete-changed-uris
 WSTOOL_UPDATE_RESULT=$?
 cd $HOME/ros/melodic
-catkin clean aques_talk collada_urdf_jsk_patch -y
+catkin clean aques_talk collada_urdf_jsk_patch libcmt -y
 catkin init
 catkin config -DCMAKE_BUILD_TYPE=Release
 catkin build


### PR DESCRIPTION
We need `catkin clean libcmt` because new patch is added in https://github.com/jsk-ros-pkg/jsk_3rdparty/commit/d07bae6defecb27c8e7858d4d02abba2eef93596#

I think `catkin clean libcmt` before `catkin build libcmt` in daily update_workspace.sh is good solution.