### PR TITLE
[jsk_robot_startup] Make the shutdown/reboot commands rosparam

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -35,6 +35,7 @@
     <rosparam>
       duration: 180
       charge_level_threshold: 80.0
+      shutdown_level_threshold: 60.0
       charge_level_step: 10.0
       volume: 1.0
     </rosparam>

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/battery_warning.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/battery_warning.py
@@ -8,6 +8,7 @@ import subprocess
 import yaml
 from sound_play.libsoundplay import SoundClient
 
+from std_msgs.msg import Empty
 from power_msgs.msg import BatteryState
 
 
@@ -16,13 +17,17 @@ class BatteryWarning(object):
         self.client_en = SoundClient(sound_action='/sound_play', blocking=True)
         self.client_jp = SoundClient(sound_action='/robotsound_jp', blocking=True)
         self.duration = rospy.get_param('~duration', 180.0)
-        self.threshold = rospy.get_param('~charge_level_threshold', 80.0)
+        self.charge_threshold = rospy.get_param('~charge_level_threshold', 80.0)
         self.step = rospy.get_param('~charge_level_step', 10.0)
+        self.shutdown_threshold = rospy.get_param('~shutdown_level_threshold', 20.0)
+        if self.charge_threshold <= self.shutdown_threshold:
+            rospy.logwarn('charge threshold should be greater than shutdown threshold.')
         self.volume = rospy.get_param('~volume', 1.0)
         address_yaml = rospy.get_param(
             '~address_yaml', "/var/lib/robot/battery_warning_address.yaml")
         self.subscriber = rospy.Subscriber(
             '/battery_state', BatteryState, self._cb, queue_size=1)
+        self.shutdown_pub = rospy.Publisher('/shutdown', Empty, queue_size=1)
         self.timer = rospy.Timer(rospy.Duration(self.duration), self._timer_cb)
         self.charge_level = None
         self.prev_charge_level = None
@@ -61,7 +66,16 @@ class BatteryWarning(object):
                     sender_address, receiver_address))
 
     def _warn(self):
-        if self.charge_level < self.threshold and not self.is_charging:
+        if self.charge_level < self.shutdown_threshold and not self.is_charging:
+            rospy.logerr("Low battery: only {}% remaining".format(self.charge_level))
+            sentence_jp = "バッテリー残り{}パーセントです。".format(self.charge_level)
+            sentence_jp += "もう限界ですので、バッテリー保護のためシャットダウンします。"
+            sentence_en = "My battery is {} percent remaining.".format(self.charge_level)
+            sentence_en += "I'm going to shut down to protect the battery."
+            self._speak(self.client_jp, sentence_jp, 'jp')
+            self._speak(self.client_en, sentence_en)
+            self.shutdown_pub.publish(Empty())
+        elif self.charge_level < self.charge_threshold and not self.is_charging:
             rospy.logerr("Low battery: only {}% remaining".format(self.charge_level))
             sentence_battery_jp = "バッテリー残り{}パーセントです。".format(self.charge_level)
             sentence_action_jp = "もう限界ですので、僕をお家にかえしてください。"

--- a/jsk_robot_common/jsk_robot_startup/README.md
+++ b/jsk_robot_common/jsk_robot_startup/README.md
@@ -173,6 +173,42 @@ This node publish the luminance calculated from input image and room light statu
 
   Image transport hint.
 
+## scripts/shutdown.py
+
+This node shuts down or reboots the robot itself according to the rostopic. Note that this node needs to be run with sudo privileges.
+
+### Subscribing Topics
+
+* `shutdown` (`std_msgs/Empty`)
+
+  Input topic that trigger shutdown
+
+* `reboot` (`std_msgs/Empty`)
+
+  Input topic that trigger reboot
+
+### Parameters
+
+* `~shutdown_command` (String, default: "/sbin/shutdown -h now")
+
+  Command to shutdown the system. You can specify the shutdown command according to your system.
+
+* `~reboot_command` (String, default: "/sbin/shutdown -r now")
+
+  Command to reboot the system. You can specify the reboot command according to your system.
+
+### Usage
+
+```
+# Launch node
+$ su [sudo user] -c ". [setup.bash]; rosrun jsk_robot_startup shutdown.py"
+# To shutdown robot
+rostopic pub /shutdown std_msgs/Empty
+# To restart robot
+rostopic pub /reboot std_msgs/Empty
+```
+
+
 ## launch/safe_teleop.launch
 
 This launch file provides a set of nodes for safe teleoperation common to mobile robots. Robot-specific nodes such as `/joy`, `/teleop` or `/cable_warning` must be included in the teleop launch file for each robot, such as [safe_teleop.xml for PR2](https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_move_base/safe_teleop.xml) or [safe_teleop.xml for fetch](https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml).

--- a/jsk_robot_common/jsk_robot_startup/scripts/shutdown.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/shutdown.py
@@ -26,22 +26,24 @@ class Shutdown(object):
         rospy.loginfo('Start shutdown node.')
         rospy.Subscriber('shutdown', Empty, self.shutdown)
         rospy.Subscriber('reboot', Empty, self.reboot)
+        self.shutdown_command = rospy.get_param(
+            '~shutdown_command', '/sbin/shutdown -h now')
+        self.reboot_command = rospy.get_param(
+            '~reboot_command', '/sbin/shutdown -r now')
 
     def shutdown(self, msg):
         rospy.loginfo('Shut down robot.')
-        shutdown_command = '/sbin/shutdown -h now'
-        ret = os.system(shutdown_command)
+        ret = os.system(self.shutdown_command)
         if ret != 0:
             rospy.logerr("Failed to call '$ {}'. Check authentication.".format(
-                shutdown_command))
+                self.shutdown_command))
 
     def reboot(self, msg):
         rospy.loginfo('Reboot robot.')
-        reboot_command = '/sbin/shutdown -r now'
-        ret = os.system(reboot_command)
+        ret = os.system(self.reboot_command)
         if ret != 0:
             rospy.logerr("Failed to call '$ {}'. Check authentication.".format(
-                reboot_command))
+                self.reboot_command))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Cherry-pick https://github.com/jsk-ros-pkg/jsk_robot/pull/1431

`Add node to shut down or reboot robot itself` commit
and
`Add supervisor job to launch shutdown.py` commit
are already merged into knorth55/jsk_robot fetch15 branch, so I did not cherry-picked them.