### PR TITLE
Revert "Merge pull request #176 from 708yamaguchi/rosdep-install-everyday"

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/update_workspace.sh
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/update_workspace.sh
@@ -13,9 +13,6 @@ wstool foreach --git 'git stash'
 wstool update --delete-changed-uris
 WSTOOL_UPDATE_RESULT=$?
 cd $HOME/ros/melodic
-rosdep update
-rosdep install --from-paths src --ignore-src -y -r
-ROSDEP_INSTALL_RESULT=$?
 catkin clean aques_talk collada_urdf_jsk_patch libcmt -y
 catkin init
 catkin config -DCMAKE_BUILD_TYPE=Release
@@ -25,9 +22,6 @@ CATKIN_BUILD_RESULT=$?
 MAIL_BODY=""
 if [ $WSTOOL_UPDATE_RESULT -ne 0 ]; then
     MAIL_BODY=$MAIL_BODY"Please wstool update workspace manually. "
-fi
-if [ $ROSDEP_INSTALL_RESULT -ne 0 ]; then
-    MAIL_BODY=$MAIL_BODY"Please rosdep install manually. "
 fi
 if [ $CATKIN_BUILD_RESULT -ne 0 ]; then
     MAIL_BODY=$MAIL_BODY"Please catkin build workspace manually."


### PR DESCRIPTION
Sorry, but I revert https://github.com/knorth55/jsk_robot/pull/176

We cannot do `rosdep install` in `update_workspace.sh` because we cannot use `sudo` in `update_workspace.sh`.