### PR TITLE
Suppress warnings when using :fast in :angle-vector

### DIFF
--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -115,8 +115,8 @@ Example usage:
                             (subseq args (+ (position :use-torso args) 2))))))
      (return-from :angle-vector (send* self :angle-vector-raw av tm ctype start-time args)))
    ;;
-   (when (not (numberp tm))
-     (ros::warn ":angle-vector tm is not a number, use :angle-vector av tm args"))
+   (when (and (not (numberp tm)) (not (eql tm :fast)))
+     (ros::warn ":angle-vector tm is not a number, use :angle-vector av tm args~%"))
    (send* self :angle-vector-motion-plan av :ctype ctype :move-arm :rarm :total-time tm
                :start-offset-time (if start-offset-time start-offset-time start-time)
                :clear-velocities clear-velocities :use-torso use-torso args)))

--- a/jsk_fetch_robot/fetcheus/fetch-utils.l
+++ b/jsk_fetch_robot/fetcheus/fetch-utils.l
@@ -5,16 +5,40 @@
 
 (defmethod fetch-robot
   (:inverse-kinematics
-   (target-coords &rest args &key link-list move-arm (use-torso t) move-target &allow-other-keys)
+   (target-coords &rest args &key link-list move-arm (use-torso t)
+                  use-base (start-coords (send self :copy-worldcoords))
+                  (base-range (list :min #f(-30 -30 -30)
+                                    :max #f( 30  30  30)))
+                  move-target &allow-other-keys)
    (unless move-arm (setq move-arm :rarm))
    (unless move-target (setq move-target (send self :rarm :end-coords)))
    (unless link-list
      (setq link-list (send self :link-list (send move-target :parent)
                            (unless use-torso (car (send self :rarm))))))
-   (send-super* :inverse-kinematics target-coords
-                :move-target move-target
-                :link-list link-list
-                args))
+   (cond
+     (use-base
+      (let ((diff-pos-rot
+             (concatenate float-vector
+                          (send start-coords :difference-position self)
+                          (send start-coords :difference-rotation self))))
+        (send self :move-to start-coords :world)
+        (with-append-root-joint
+            (ll self link-list
+                :joint-class omniwheel-joint
+                :joint-args base-range)
+          (send (caar ll) :joint :joint-angle
+                (float-vector (elt diff-pos-rot 0)
+                              (elt diff-pos-rot 1)
+                              (rad2deg (elt diff-pos-rot 5))))
+          (send-super* :inverse-kinematics target-coords
+                       :move-target move-target
+                       :link-list ll  ;; link-list
+                       args))))
+     (t
+      (send-super* :inverse-kinematics target-coords
+                   :move-target move-target
+                   :link-list link-list
+                   args))))
   (:go-grasp
     (&key (pos 0)) ;; pos is between 0.0 and 0.1
       (send self :l_gripper_finger_joint :joint-angle (/ (* pos 1000) 2)) ;; m -> mm


### PR DESCRIPTION
From `:angle-vector-motion-plan` description:

```lisp
- total-time : time to execute the whole motion in [msec]
   if designated total-time is shorter than the planned time, use the planned time
   if not specified, use the planned time
   if :fast is specified, use 'scale' times of the planned time
```