### PR TITLE
[jsk_fetch_startup] Fix not launching rviz in go-to-kitchen demo

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -1,6 +1,6 @@
 display: Go to kitchen
 platform: fetch
-run: jsk_fetch_startup/go-to-kitchen.l
+launch: jsk_fetch_startup/go-to-kitchen.xml
 interface: jsk_fetch_startup/go_to_kitchen.interface
 icon: jsk_fetch_startup/go_to_kitchen.png
 timeout: 1200


### PR DESCRIPTION
These days rviz is not launching in go-to-kitchen demo. I fix it in this pull request.
I changed `run` ==> `launch` because other program is launching in kitchen demo.

@Affonso-Gui
If you have any problems with this change, please let me know.
