### PR TITLE
Revert "[jsk_fetch_startup] Fix not launching rviz in go-to-kitchen demo"

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -1,6 +1,6 @@
 display: Go to kitchen
 platform: fetch
-launch: jsk_fetch_startup/go-to-kitchen.xml
+run: jsk_fetch_startup/go-to-kitchen.l
 interface: jsk_fetch_startup/go_to_kitchen.interface
 icon: jsk_fetch_startup/go_to_kitchen.png
 timeout: 1200


### PR DESCRIPTION
Reverts knorth55/jsk_robot#187

Sorry,
`go-to-kitchen.xml` should be `go_to_kitchen.xml`