### PR TITLE
[jsk_fetch_startup] Supress L515 ERROR messages

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_realsense_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_realsense_bringup.launch
@@ -98,6 +98,7 @@
       <arg name="clip_distance"         value="-2"/>
       <arg name="enable_pointcloud"     value="true"/>
       <arg name="enable_infra"          value="true"/>
+      <arg name="enable_confidence"     value="false"/>
       <arg name="respawn"              value="$(arg respawn)"/>
     </include>
   </group>


### PR DESCRIPTION
Supress L515 error
```
[ERROR] [1649392036.397779147] [/l515_head/l515_head_realsense2_camera:ros.realsense2_camera]: An error has occurred during frame callback: map::at
```

Thank you very much for your help @iory