### PR TITLE
[jsk_fetch_startup] Add image hertz converter for recording kitchen demo

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -19,7 +19,7 @@ plugins:
       audio_sample_rate: 16000
       audio_format: wave
       audio_sample_format: S16LE
-      video_topic_name: /head_camera/rgb/image_rect_color
+      video_topic_name: /head_camera/rgb/image_rect_color/hz_converted
       video_height: 480
       video_width: 640
       video_framerate: 30
@@ -34,10 +34,10 @@ plugins:
       audio_sample_rate: 16000
       audio_format: wave
       audio_sample_format: S16LE
-      video_topic_name: /edgetpu_object_detector/output/image
+      video_topic_name: /edgetpu_object_detector/output/image/hz_converted
       video_height: 480
       video_width: 640
-      video_framerate: 10
+      video_framerate: 30
       video_encoding: RGB
   - name: panorama_video_recorder_plugin
     type: app_recorder/video_recorder_plugin

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
@@ -7,6 +7,27 @@
     <param name="score_thresh" type="double" value="0.60" /> <!-- default: 0.6 -->
   </node>
 
+  <!-- Image topic hz converter -->
+  <node name="head_camera_image_hz_converter"
+        pkg="jsk_fetch_startup"
+        type="image_hz_converter.py">
+    <remap from="~input" to="/head_camera/rgb/image_rect_color" />
+    <remap from="~output" to="/head_camera/rgb/image_rect_color/hz_converted" />
+    <rosparam>
+      image_hz: 30
+    </rosparam>
+  </node>
+
+  <node name="object_detect_image_hz_converter"
+        pkg="jsk_fetch_startup"
+        type="image_hz_converter.py">
+    <remap from="~input" to="/edgetpu_object_detector/output/image" />
+    <remap from="~output" to="/edgetpu_object_detector/output/image/hz_converted" />
+    <rosparam>
+      image_hz: 30
+    </rosparam>
+  </node>
+
   <!-- Use m5stack_ros -->
   <!-- See https://github.com/jsk-ros-pkg/jsk_3rdparty/pull/289 -->
   <node name="rosserial_m5stack" pkg="rosserial_python" type="serial_node.py">

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/image_hz_converter.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/image_hz_converter.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+import rospy
+from sensor_msgs.msg import Image
+
+
+class ImageHzConverter:
+    """
+    This class converts image topic hz
+    """
+    def __init__(self):
+        self.topic_hz = rospy.get_param('image_hz', 30)
+        self.output = Image()
+        self.image_sub = rospy.Subscriber(
+            "~input", Image, self.image_callback)
+        self.pub = rospy.Publisher(
+            "~output", Image, queue_size=1)
+        rospy.Timer(
+            rospy.Duration(1.0/float(self.topic_hz)),
+            self.hz_converter,
+            oneshot=False)
+        rospy.loginfo('image hz convert starting')
+
+    def image_callback(self, msg):
+        self.output = msg
+
+    def hz_converter(self, event):
+        self.output.header.stamp = rospy.Time.now()
+        self.pub.publish(self.output)
+
+
+if __name__ == '__main__':
+    rospy.init_node('image_hz_converter', anonymous=True)
+    image_hz_converter = ImageHzConverter()
+    rospy.spin()


### PR DESCRIPTION
This pull request addresses the issue of the incorrect correspondence between audio and video in the recording video of kitchen demo.
Specifically in this change, the previous image topic is continued to publish until the next image topic is published to be a specific frequency.

- before (audio and video not syncronized): https://drive.google.com/uc?id=1z4PNl8J-YN436_ncONAtY3mn7nP-CtBa
- after (syncronized better): https://drive.google.com/uc?id=1H1P82VCIQxVoxVj58Vei70mx7OZXL07F

I'm also thinking a little that it might be better to move `image_hz_converter.py` to something like `jsk_topic_tools`  not only for `sensor_msgs/Image` but also for more general topics.
