### PR TITLE
Pr/fetchdev/update workspace script 20220416

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -65,10 +65,6 @@
     uri: https://github.com/knorth55/app_manager_utils
     version: master
 - git:
-    local-name: locusrobotics/catkin_virtualenv
-    uri: https://github.com/locusrobotics/catkin_virtualenv.git
-    version: 0.5.0
-- git:
     local-name: mikeferguson/robot_calibration
     uri: https://github.com/mikeferguson/robot_calibration.git
     version: 0.5.5

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/update_workspace.sh
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/update_workspace.sh
@@ -14,6 +14,8 @@ fi
 ln -sf $(rospack find jsk_fetch_startup)/../jsk_fetch.rosinstall.$ROS_DISTRO $HOME/ros/melodic/src/.rosinstall
 wstool foreach --git 'git stash'
 wstool update --delete-changed-uris
+wstool foreach --git 'branch-name=$(git rev-parse --abbrev-ref HEAD) && git reset --hard HEAD && git checkout origin/$branch-name && git branch -D $branch-name && git checkout $branch-name' # Forcefully checkout specified branch
+wstool update
 WSTOOL_UPDATE_RESULT=$?
 # Build workspace
 cd $HOME/ros/melodic

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/update_workspace.sh
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/update_workspace.sh
@@ -8,10 +8,14 @@ LOGFILE=$HOME/ros/melodic/update_workspace.txt
 set -x
 # Update workspace
 cd $HOME/ros/melodic/src
+if [ -e $HOME/ros/melodic/src/.rosinstall]; then
+    rm $HOME/ros/melodic/src/.rosinstall
+fi
 ln -sf $(rospack find jsk_fetch_startup)/../jsk_fetch.rosinstall.$ROS_DISTRO $HOME/ros/melodic/src/.rosinstall
 wstool foreach --git 'git stash'
 wstool update --delete-changed-uris
 WSTOOL_UPDATE_RESULT=$?
+# Build workspace
 cd $HOME/ros/melodic
 catkin clean aques_talk collada_urdf_jsk_patch libcmt -y
 catkin init

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/update_workspace.sh
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/update_workspace.sh
@@ -8,9 +8,6 @@ LOGFILE=$HOME/ros/melodic/update_workspace.txt
 set -x
 # Update workspace
 cd $HOME/ros/melodic/src
-if [ -e $HOME/ros/melodic/src/.rosinstall]; then
-    rm $HOME/ros/melodic/src/.rosinstall
-fi
 ln -sf $(rospack find jsk_fetch_startup)/../jsk_fetch.rosinstall.$ROS_DISTRO $HOME/ros/melodic/src/.rosinstall
 wstool foreach --git 'git stash'
 wstool update --delete-changed-uris


### PR DESCRIPTION
- Remove catkin_virtualenv entry from rosinstall. (We have to remove catkin_virtualenv in catkin workspace manually.)
- Checkout the specified branch even when local branch and remote branch have diverged.