### PR TITLE
Use coral in default workspace

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -133,3 +133,8 @@
     local-name: ros-planning/navigation
     uri: https://github.com/708yamaguchi/navigation.git
     version: fetch15
+# Use coral_usb_ros + cv_bridge_python3
+- git:
+    local-name: jsk-ros-pkg/coral_usb_ros
+    uri: https://github.com/jsk-ros-pkg/coral_usb_ros.git
+    version: master

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-human-pose-estimator.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-human-pose-estimator.conf
@@ -1,8 +1,10 @@
 [program:jsk-human-pose-estimator]
-command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/coral_ws/devel/setup.bash && roslaunch coral_usb edgetpu_human_pose_estimator.launch INPUT_IMAGE:=/head_camera/rgb/image_rect_color device_id:=0 --screen --wait"
+; command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/coral_ws/devel/setup.bash && roslaunch coral_usb edgetpu_human_pose_estimator.launch INPUT_IMAGE:=/head_camera/rgb/image_rect_color device_id:=0 --screen --wait"
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && roslaunch coral_usb edgetpu_human_pose_estimator.launch INPUT_IMAGE:=/head_camera/rgb/image_rect_color device_id:=0 --screen --wait"
 
 stopsignal=TERM
-directory=/home/fetch/ros/coral_ws
+; directory=/home/fetch/ros/coral_ws
+directory=/home/fetch/ros/melodic
 ; You can set "autostart=true" if "autostart=false" in jsk-panorama-human-pose-estimator.conf
 autostart=true
 autorestart=false

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-object-detector.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-object-detector.conf
@@ -1,8 +1,10 @@
 [program:jsk-object-detector]
-command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/coral_ws/devel/setup.bash && roslaunch coral_usb edgetpu_object_detector.launch INPUT_IMAGE:=/head_camera/rgb/image_rect_color model_file:=/home/fetch/.ros/data/coral_usb/mobilenet_v2_ssd_73b2_kitchen_finetuning_20200528.tflite label_file:=/home/fetch/.ros/data/coral_usb/73b2_kitchen_labels.txt device_id:=1 --screen --wait"
+; command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/coral_ws/devel/setup.bash && roslaunch coral_usb edgetpu_object_detector.launch INPUT_IMAGE:=/head_camera/rgb/image_rect_color model_file:=/home/fetch/.ros/data/coral_usb/mobilenet_v2_ssd_73b2_kitchen_finetuning_20200528.tflite label_file:=/home/fetch/.ros/data/coral_usb/73b2_kitchen_labels.txt device_id:=1 --screen --wait"
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && roslaunch coral_usb edgetpu_object_detector.launch INPUT_IMAGE:=/head_camera/rgb/image_rect_color model_file:=/home/fetch/.ros/data/coral_usb/mobilenet_v2_ssd_73b2_kitchen_finetuning_20200528.tflite label_file:=/home/fetch/.ros/data/coral_usb/73b2_kitchen_labels.txt device_id:=1 --screen --wait"
 
 stopsignal=TERM
-directory=/home/fetch/ros/coral_ws
+; directory=/home/fetch/ros/coral_ws
+directory=/home/fetch/ros/melodic
 ; You can set "autostart=true" if "autostart=false" in jsk-panorama-object-detector.conf
 autostart=true
 autorestart=false

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-panorama-human-pose-estimator.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-panorama-human-pose-estimator.conf
@@ -1,8 +1,10 @@
 [program:jsk-panorama-human-pose-estimator]
-command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/coral_ws/devel/setup.bash && roslaunch coral_usb edgetpu_panorama_human_pose_estimator.launch nodename:=edgetpu_human_pose_estimator INPUT_IMAGE:=/dual_fisheye_to_panorama/quater/output device_id:=0 --screen --wait"
+; command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/coral_ws/devel/setup.bash && roslaunch coral_usb edgetpu_panorama_human_pose_estimator.launch nodename:=edgetpu_human_pose_estimator INPUT_IMAGE:=/dual_fisheye_to_panorama/quater/output device_id:=0 --screen --wait"
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && roslaunch coral_usb edgetpu_panorama_human_pose_estimator.launch nodename:=edgetpu_human_pose_estimator INPUT_IMAGE:=/dual_fisheye_to_panorama/quater/output device_id:=0 --screen --wait"
 
 stopsignal=TERM
-directory=/home/fetch/ros/coral_ws
+; directory=/home/fetch/ros/coral_ws
+directory=/home/fetch/ros/melodic
 ; You can set "autostart=true" if "autostart=false" in jsk-human-pose-estimator.conf
 autostart=false
 autorestart=false

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-panorama-object-detector.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-panorama-object-detector.conf
@@ -1,8 +1,10 @@
 [program:jsk-panorama-object-detector]
-command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/coral_ws/devel/setup.bash && roslaunch coral_usb edgetpu_panorama_object_detector.launch nodename:=edgetpu_object_detector INPUT_IMAGE:=/dual_fisheye_to_panorama/quater/output model_file:=/home/fetch/.ros/data/coral_usb/mobilenet_v2_ssd_73b2_kitchen_finetuning_20200528.tflite label_file:=/home/fetch/.ros/data/coral_usb/73b2_kitchen_labels.txt device_id:=1 --screen --wait"
+; command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/coral_ws/devel/setup.bash && roslaunch coral_usb edgetpu_panorama_object_detector.launch nodename:=edgetpu_object_detector INPUT_IMAGE:=/dual_fisheye_to_panorama/quater/output model_file:=/home/fetch/.ros/data/coral_usb/mobilenet_v2_ssd_73b2_kitchen_finetuning_20200528.tflite label_file:=/home/fetch/.ros/data/coral_usb/73b2_kitchen_labels.txt device_id:=1 --screen --wait"
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && roslaunch coral_usb edgetpu_panorama_object_detector.launch nodename:=edgetpu_object_detector INPUT_IMAGE:=/dual_fisheye_to_panorama/quater/output model_file:=/home/fetch/.ros/data/coral_usb/mobilenet_v2_ssd_73b2_kitchen_finetuning_20200528.tflite label_file:=/home/fetch/.ros/data/coral_usb/73b2_kitchen_labels.txt device_id:=1 --screen --wait"
 
 stopsignal=TERM
-directory=/home/fetch/ros/coral_ws
+; directory=/home/fetch/ros/coral_ws
+directory=/home/fetch/ros/melodic
 ; You can set "autostart=true" if "autostart=false" in jsk-object-detector.conf
 autostart=false
 autorestart=false


### PR DESCRIPTION
With `cv_bridge_python3`, now we can build coral in default workspace.
see: https://github.com/jsk-ros-pkg/coral_usb_ros/pull/91