### PR TITLE
[Merge after knorth55/jsk_common#3] [jsk_fetch_startup] Use image hz convert for recording kitchen demo

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -19,7 +19,7 @@ plugins:
       audio_sample_rate: 16000
       audio_format: wave
       audio_sample_format: S16LE
-      video_topic_name: /head_camera/rgb/image_rect_color
+      video_topic_name: /head_camera/rgb/image_rect_color/hz_converted
       video_height: 480
       video_width: 640
       video_framerate: 30
@@ -34,10 +34,10 @@ plugins:
       audio_sample_rate: 16000
       audio_format: wave
       audio_sample_format: S16LE
-      video_topic_name: /edgetpu_object_detector/output/image
+      video_topic_name: /edgetpu_object_detector/output/image/hz_converted
       video_height: 480
       video_width: 640
-      video_framerate: 10
+      video_framerate: 30
       video_encoding: RGB
   - name: panorama_video_recorder_plugin
     type: app_recorder/video_recorder_plugin

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
@@ -7,6 +7,27 @@
     <param name="score_thresh" type="double" value="0.60" /> <!-- default: 0.6 -->
   </node>
 
+  <!-- Image topic hz converter for better synchronization betweeen audio and video-->
+  <node name="head_camera_image_hz_converter"
+        pkg="jsk_topic_tools"
+        type="topic_hz_converter.py">
+    <remap from="~input" to="/head_camera/rgb/image_rect_color" />
+    <remap from="~output" to="/head_camera/rgb/image_rect_color/hz_converted" />
+    <rosparam>
+      desired_topic_hz: 30
+    </rosparam>
+  </node>
+
+  <node name="object_detect_image_hz_converter"
+        pkg="jsk_topic_tools"
+        type="topic_hz_converter.py">
+    <remap from="~input" to="/edgetpu_object_detector/output/image" />
+    <remap from="~output" to="/edgetpu_object_detector/output/image/hz_converted" />
+    <rosparam>
+      desired_topic_hz: 30
+    </rosparam>
+  </node>
+
   <!-- Use m5stack_ros -->
   <!-- See https://github.com/jsk-ros-pkg/jsk_3rdparty/pull/289 -->
   <node name="rosserial_m5stack" pkg="rosserial_python" type="serial_node.py">


### PR DESCRIPTION
Moved from #195
Merge after knorth55/jsk_common#3

This pull request addresses the issue of the incorrect correspondence between audio and video in the recording video of kitchen demo by keeping the topic hz stable.