### PR TITLE
[jsk_fetch_startup] Update rosinstall because upstream dependency is solved

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -1,12 +1,10 @@
 # This is rosinstall file for melodic PC inside fetch.
 # $ ln -s $(rospack find jsk_fetch_startup)/../jsk_fetch.rosinstall.$ROS_DISTRO $HOME/ros/$ROS_DISTRO/src/.rosinstall
 
-# Use https://github.com/PR2/app_manager.git kinetic-devel branch
-# after https://github.com/PR2/app_manager/pull/49 is merged
 - git:
     local-name: PR2/app_manager
-    uri: https://github.com/knorth55/app_manager.git
-    version: fetch15
+    uri: https://github.com/PR2/app_manager.git
+    version: kinetic-devel
 - git:
     local-name: RobotWebTools/rosbridge_suite
     uri: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
I cherry-pick [jsk-ros-pkg/jsk_robot@`ea1a9b7` (#1452)](https://github.com/jsk-ros-pkg/jsk_robot/pull/1452/commits/ea1a9b7dd5b081265c7958851b951794d26ded1c)
