### PR TITLE
[Fetch] Update rosinstall to use fetch15 branch of jsk_common

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -26,11 +26,17 @@
     local-name: jsk-ros-pkg/jsk_3rdparty
     uri: https://github.com/knorth55/jsk_3rdparty.git
     version: fetch15
+# we need to use the development branch until PR below are merged.
+#  - https://github.com/jsk-ros-pkg/jsk_common/pull/1719
 # Waiting 2.2.12 release
+# - git:
+#     local-name: jsk-ros-pkg/jsk_common
+#     uri: https://github.com/jsk-ros-pkg/jsk_common.git
+#     version: master
 - git:
     local-name: jsk-ros-pkg/jsk_common
-    uri: https://github.com/jsk-ros-pkg/jsk_common.git
-    version: master 
+    uri: https://github.com/knorth55/jsk_common.git
+    version: fetch15
 # we need to use the development branch (fetch15 branch in knorth55's fork)
 # until it is merged to master
 - git:


### PR DESCRIPTION
Update jsk_fetch.rosinstall.melodic to use knorth55/jsk_common#3.
jsk-ros-pkg/jsk_common -> knorth55/jsk_common