### PR TITLE
use app_manager fetch15 branch

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -3,8 +3,8 @@
 
 - git:
     local-name: PR2/app_manager
-    uri: https://github.com/PR2/app_manager.git
-    version: kinetic-devel
+    uri: https://github.com/knorth55/app_manager.git
+    version: fetch15 
 - git:
     local-name: RobotWebTools/rosbridge_suite
     uri: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
@Affonso-Gui
Please make a PR in `app_manager` repo.
`knorth55/app_manager@fetch15` merges `Affonso-Gui/app_manager@devel` branch.
This branch add `run` arguments to start the app in `rosrun` not `roslaunch`.

https://github.com/knorth55/app_manager/tree/fetch15
https://github.com/knorth55/jsk_robot/commit/beb30f497f942b72b30434a6820d365bf0382e6c
