### PR TITLE
[jsk_fetch_startup] Remove duplicated diagnostics aggregator

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch.launch
@@ -2,6 +2,7 @@
   <!-- add arg launch_teleop: yamaguchi & s-kitagawa (2019/04/19) -->
   <arg name="launch_teleop" default="true" />
   <arg name="launch_moveit" default="true" />
+  <arg name="launch_diagnostics_agg" default="false" />
 
   <!-- options for robot_description -->
   <arg name="use_fetch_description" default="false" />
@@ -188,6 +189,7 @@
   </group>
 
   <!-- Diagnostics Aggregator -->
-  <include file="$(find fetch_bringup)/launch/include/aggregator.launch.xml"/>
+  <include if="$(arg launch_diagnostics_agg)"
+           file="$(find fetch_bringup)/launch/include/aggregator.launch.xml"/>
 
 </launch>


### PR DESCRIPTION
There are two `diagnostic_aggregator` node in fetch's launch file.
`fetch_bringup.launch`'s aggregator includes `fetch.launch`'s aggregator.
So I remove the `fetch.launch`'s aggregator.

https://github.com/knorth55/jsk_robot/blob/b2999b0cece82d7b1d46320a1e7c84e4fc078bd2/jsk_fetch_robot/jsk_fetch_startup/launch/fetch.launch#L190-L191
https://github.com/knorth55/jsk_robot/blob/b2999b0cece82d7b1d46320a1e7c84e4fc078bd2/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch#L92-L96

