### PR TITLE
[jsk_fetch_startup] Use audible_warning to speak diagnostics

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -105,6 +105,11 @@
     <param name="load5_threshold" value="5.0"/>
   </node>
 
+  <!-- diagnostic speaker -->
+  <node name="audible_warning" pkg="jsk_tools" type="audible_warning.py">
+    <remap from="/robotsound" to="/sound_play" />
+  </node>
+
   <!-- twitter -->
   <include file="$(find jsk_fetch_startup)/launch/fetch_tweet.launch" if="$(arg fetch_tweet)"/>
 


### PR DESCRIPTION
I use `jsk_tools/audible_warning.py` instead of `jsk_fetch_startup/warning.py`'s function of speaking diagnostic.
https://github.com/jsk-ros-pkg/jsk_common/pull/1607

I think it is important to unify the function of speaking diagnostic.