### PR TITLE
[jsk_pr2_startup] Use audible_warning to speak diagnostics

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/pr2.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/pr2.launch
@@ -197,4 +197,7 @@
     <remap from="~input" to="/kinect_head/rgb/image_raw" />
   </node>
 
+  <!-- diagnostic speaker -->
+  <node name="audible_warning" pkg="jsk_tools" type="audible_warning.py" />
+
 </launch>


### PR DESCRIPTION
PR2 version of https://github.com/knorth55/jsk_robot/pull/223

I use `jsk_tools/audible_warning.py` for PR2 to speak diagnostics.