### PR TITLE
Set unregister_timeout in rosbridge_websocket

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/lifelog/app_manager.launch
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/app_manager.launch
@@ -44,6 +44,7 @@
         delay_between_messages: 0
         max_message_size: None
         fragment_timeout: 600
+        unregister_timeout: 100000000
       </rosparam>
     </node>
     <node name="rosapi" pkg="rosapi" type="rosapi_node"


### PR DESCRIPTION
Unregistering topics in roslibjs (scratch) is giving me the following error:
```
2022-05-19 18:18:00+0900 [-] [WARN] [1652951880.334198] [/rosbridge_websocket:rosout]: Could not process inbound connection: [/rosbridge_websocket] is not a publisher of [/sound_play/goal]. 
Topics are [[' /client_count', 'std_msgs/Int32'], ['/rosout', 'rosgraph_msgs/Log'], ['/connected_clients', 'rosbridge_msgs/ConnectedClients']]
{'message_definition': "...", 'callerid': '/sound_play', 'tcp_nodelay': '0', 'md5sum': '7ff89ce2a5f72c86a28be8ae82658bf8', 'topic': '/sound_play/goal', 'type': 'sound_play/SoundRequestActionGoal'}
```

This is an old problem, but it still seems to be around:
https://github.com/RobotWebTools/rosbridge_suite/issues/298
https://github.com/RobotWebTools/rosbridge_suite/issues/138

For now, I am entering a very long timeout as a workaround.

@iory