### PR TITLE
[jsk_fetch_robot] Use mongodb_store which can manage logerr throttle …

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -90,10 +90,13 @@
     local-name: ros/common_msgs/visualization_msgs
     uri: https://github.com/ros-gbp/common_msgs-release/archive/release/kinetic/visualization_msgs/1.12.7-0.tar.gz
     version: common_msgs-release-release-kinetic-visualization_msgs-1.12.7-0
+# Following error is output at about 25Hz for about 4 hours
+# [ERROR] [1653231340.987602] [/replicator_node:rosout]: [mongorestore] - E11000 duplicate key error collection: jsk_robot_lifelog.fetch1075 index: _id_ dup key: { : ObjectId('6243af9651998d10f0c7787c') }
+# Errors are now output once per hour
 - git:
     local-name: strands-project/mongodb_store
-    uri: https://github.com/strands-project/mongodb_store.git
-    version: 0.4.4
+    uri: https://github.com/708yamaguchi/mongodb_store.git
+    version: fetch15
 # we need to use the develop branch for basic authentication
 - git:
     local-name: tork-a/roswww

--- a/jsk_robot_common/jsk_robot_startup/lifelog/mongodb.launch
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/mongodb.launch
@@ -34,6 +34,7 @@
     <arg name="repl_set" value="rs0"
          if="$(arg repl_set_mode)" />
     <arg name="replicator_dump_path" value="$(arg replicator_dump_path)" />
+    <arg name="logerr_period" default="3600" />
     <arg name="test_mode" value="$(arg test_mode)" />
   </include>
 


### PR DESCRIPTION
From https://github.com/knorth55/jsk_robot/issues/234
PR to jsk-ros-pkg https://github.com/jsk-ros-pkg/jsk_robot/pull/1487

When using fetch, it is difficult to debug because it sometimes throws out a large number of errors such as the following.

```
[ERROR] [1653231340.987602] [/replicator_node:rosout]: [mongorestore] - E11000 duplicate key error collection: jsk_robot_lifelog.fetch1075 index: _id_ dup key: { : ObjectId('6243af9651998d10f0c7787c') }
```

By changing the code in `mongodb_store`, I throttle the error log.
https://github.com/strands-project/mongodb_store/pull/271

@knorth55 
Could you review this PR and `708yamaguchi/monbodb_store fetch15 branch`?