### PR TITLE
[jsk_robot_startup] Send kitchen demo mail with embed images

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -383,10 +383,12 @@
                     :with-image "/edgetpu_object_detector/output/image" :speak t)
       (notify-recognition :location "kitchen stove")
       (notify-co2 :location "kitchen stove")
+      (take-photo "kitchen_stove.jpg")
       (send *ri* :go-pos-unsafe 0 0 -45)
       ;; sink
       (tweet-string "I took a photo at 73B2 Kitchen sink." :warning-time 3
                     :with-image "/edgetpu_object_detector/output/image" :speak t)
+      (take-photo "kitchen_sink.jpg")
       (notify-recognition :location "kitchen sink"))
     (progn
       (notify-recognition :location "kitchen"))))
@@ -435,6 +437,51 @@
     (send *ri* :go-pos-unsafe 0 0 -80) ;; face the front against the trash can
     success-move-to-trashcan-front))
 
+(defun send-kitchen-mail ()
+  (let ((msg (instance jsk_robot_startup::Email :init))
+        (stove-text (instance jsk_robot_startup::EmailBody :init))
+        (sink-text (instance jsk_robot_startup::EmailBody :init))
+        (trashcan-text (instance jsk_robot_startup::EmailBody :init))
+        (change-line (instance jsk_robot_startup::EmailBody :init))
+        (kitchen-stove-img (instance jsk_robot_startup::EmailBody :init))
+        (kitchen-sink-img (instance jsk_robot_startup::EmailBody :init))
+        (trashcan-inside-img (instance jsk_robot_startup::EmailBody :init)))
+    (ros::advertise "email" jsk_robot_startup::Email 1)
+    (send stove-text :type "text")
+    (send stove-text :message "コンロを見に行ったよ．")
+    (send sink-text :type "text")
+    (send sink-text :message "シンクを見に行ったよ．")
+    (send trashcan-text :type "text")
+    (send trashcan-text :message "ゴミ箱を見に行ったよ．")
+    (send kitchen-stove-img :type "img")
+    (send kitchen-stove-img :file_path "/tmp/kitchen_stove.jpg")
+    (send kitchen-stove-img :img_size 50)
+    (send kitchen-sink-img :type "img")
+    (send kitchen-sink-img :file_path "/tmp/kitchen_sink.jpg")
+    (send kitchen-sink-img :img_size 50)
+    (send trashcan-inside-img :type "img")
+    (send trashcan-inside-img :file_path "/tmp/trashcan_inside.jpg")
+    (send trashcan-inside-img :img_size 50)
+    (send change-line :type "html")
+    (send change-line :message "<br>")
+    (send msg :receiver_address "fetch@jsk.imi.i.u-tokyo.ac.jp")
+    (send msg :subject "キッチンを巡回したよ")
+    (send msg :body (list stove-text
+                          change-line
+                          kitchen-stove-img
+                          change-line
+                          sink-text
+                          change-line
+                          kitchen-sink-img
+                          change-line
+                          trashcan-text
+                          change-line
+                          trashcan-inside-img))
+    (unix::sleep 1)
+    (ros::ros-info "send-kitchen-mail")
+    (ros::publish "email" msg)
+    ))
+
 
 (defun go-to-kitchen (&key (tweet t) (n-dock-trial 1) (n-kitchen-trial 1)
                            (control-switchbot :api))
@@ -478,6 +525,7 @@
       (room-light-off :control-switchbot control-switchbot))
     ;; change the inflation_radius
     (restore-params)
+    (send-kitchen-mail)
     (setq success-battery-charging (equal (get-battery-charging-state) :charging))
     (and success-go-to-kitchen success-auto-dock success-battery-charging)))
 
@@ -588,6 +636,7 @@
                        (success-go-to-kitchen
                          (cdr (assoc 'success-go-to-kitchen userdata))))
                    (restore-params)
+		   (send-kitchen-mail)
                    (and success-go-to-kitchen success-auto-dock success-battery-charging)))))
           '(:init)
           '(t nil))))


### PR DESCRIPTION
Please merge after #238.
In this PR, embed images are sent with new `email_topic.py` in kitchen demo.
As a next step, I would like to add more information about recognition such as finding kettle, trashcan occupancy and so on.

<img src="https://user-images.githubusercontent.com/67531577/170499704-7a73e151-33f9-440a-b5af-4df67b636477.png" width=50%>
