### PR TITLE
[jsk_pr2_startup] Suppress PR2 audible warning

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_warning/jsk_pr2_analyzers.yaml
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_warning/jsk_pr2_analyzers.yaml
@@ -6,9 +6,9 @@ analyzers:
       joystick:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Joystick
-        expected: 'joy: Joystick Driver Status'
+        expected: 'joy_node: Joystick Driver Status'
         num_items: 1
-        remove_prefix: 'joy'
+        remove_prefix: 'joy_node'
       sound:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Sound

--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_warning/warning_blacklist.yaml
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_warning/warning_blacklist.yaml
@@ -7,6 +7,8 @@ blacklist:
   - name: "/Computers/CPU/c2 CPU Usage"
   - name: "/Devices/Joystick/Joystick Driver Status"
   - name: "/Devices/Sound"
+  - name: "/Joints/Joint.*"
+    message: "Uncalibrated"
   - name: "/Other/Accelerometer.*"
   - name: "/Other/NTP offset from"
   - name: "/Other/Pressure sensors.*"

--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_warning/warning_blacklist.yaml
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_warning/warning_blacklist.yaml
@@ -16,6 +16,7 @@ blacklist:
   - name: "/Motors/EtherCAT.*"
     message: "Safety Lockout.*"
   - name: "/Realtime Controllers/Controller.*"
+  - name: "/Realtime Controllers/Calibration stuck"
   - name: "/Computers/CPU/c\\d CPU Temperature"
 run_stop_blacklist:
   - "/Motors.*"


### PR DESCRIPTION
I did
- Fix joy node name in diagnostics analyzer
- Ignore calibration stuck because PR2 speaks this error in Japanese
- Ignore uncalibrated error because we do not need to know this error before calibration.

cc @iory