### PR TITLE
[jsk_fetch_startup] Set vital_rate 0.1 in go-to-kitchen demo

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_insta360_indigo.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_insta360_indigo.launch
@@ -1,6 +1,7 @@
 <launch>
   <!-- Insta360 images -->
   <include file="$(find jsk_perception)/sample/sample_insta360_air.launch">
+    <arg name="vital_rate" value="0.1" />
     <arg name="gui" value="false" />
     <!-- Reduce CPU load -->
     <!-- To check the valid formats, -->

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_insta360_melodic.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_insta360_melodic.launch
@@ -2,6 +2,7 @@
   <!-- Insta360 images -->
   <include file="$(find jsk_perception)/sample/sample_insta360_air.launch">
     <arg name="gui" value="false" />
+    <arg name="vital_rate" value="0.1" />
     <!-- Reduce CPU load -->
     <!-- To check the valid formats, -->
     <!-- $ sudo apt-get install v4l-utils -->

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/trashbin_occupancy_detector.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/trashbin_occupancy_detector.launch
@@ -44,6 +44,7 @@
     <remap from="camera_info" to="$(arg IMAGE_CAMERAINFO)" />
     <remap from="Feature0D" to="$(arg DEFAULT_NAMESPACE)/Feature0D" />
     <remap from="ImageFeature0D" to="$(arg DEFAULT_NAMESPACE)/ImageFeature0D" />
+    <param name="vital_rate" value="0.1" />
   </node>
 
   <group ns="$(arg DEFAULT_NAMESPACE)">
@@ -57,6 +58,7 @@
       <rosparam>
         tolerance: 0.02
         min_size: 100
+        vital_rate: 0.1
       </rosparam>
     </node>
     <node pkg="nodelet" type="nodelet"
@@ -72,6 +74,7 @@
         target_frame_id: base_link
         use_pca: true
         force_to_flip_z_axis: false
+        vital_rate: 0.1
       </rosparam>
     </node>
     


### PR DESCRIPTION
This PR suppress diagnostics errors at the start of the demo (at the start of subscribe.).
Depends on https://github.com/sktometometo/jsk_recognition/pull/4
cc @iory

This PR cannot be sent to `jsk-ros-pkg/jsk_robot` because `trashbin_occupancy_detector.launch` PR is not created to `jsk-ros-pkg/jsk_robot`.

Wait for @mqcmd196 's PR to jsk-ros-pkg.