### PR TITLE
[jsk_fetch_startup] Use smaller size images for trashbin occupancy detector

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/trashbin_occupancy_detector.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/trashbin_occupancy_detector.launch
@@ -1,6 +1,6 @@
 <launch>
-  <arg name="POINTCLOUD_INPUT" default="/head_camera/depth_registered/points"/>
-  <arg name="IMAGE_INPUT" default="/head_camera/rgb/image_rect_color"/>
+  <arg name="POINTCLOUD_INPUT" default="/head_camera/depth_registered/quater/throttled/points"/>
+  <arg name="IMAGE_INPUT" default="/head_camera/rgb/throttled/image_rect_color"/>
   <arg name="IMAGE_CAMERAINFO" default="/head_camera/rgb/camera_info"/>
   <arg name="CENTROID_FRAME" default="target"/>
   <arg name="DEFAULT_NAMESPACE" default="/trashbin_occupancy_detector"/>


### PR DESCRIPTION
Use smaller size images for trashbin occupancy detector to reduce CPU usage during `go to kitchen` demo.

I do not send this PR to jsk-ros-pkg for the same reason as https://github.com/knorth55/jsk_robot/pull/245

@mqcmd196
Is it OK to use these topics?