### PR TITLE
[jsk_fetch_startup] Launch some supervisor jobs as root

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -7,7 +7,6 @@
   <arg name="launch_app_scheduler" default="true" />
   <arg name="launch_dialogflow" default="true" />
   <arg name="launch_gdrive_server" default="true" />
-  <arg name="launch_shutdown" default="true" />
   <arg name="launch_edgetpu_human_pose_estimator" default="true" />
   <arg name="launch_edgetpu_object_detector" default="true" />
 
@@ -340,9 +339,5 @@
       duration: 60
     </rosparam>
   </node>
-
-  <!-- shutdown node -->
-  <node if="$(arg launch_shutdown)"
-        name="shutdown" pkg="jsk_robot_startup" type="shutdown.py" />
 
 </launch>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -7,7 +7,6 @@
   <arg name="launch_app_scheduler" default="true" />
   <arg name="launch_dialogflow" default="true" />
   <arg name="launch_gdrive_server" default="true" />
-  <arg name="launch_rfcomm_bind" default="true" />
   <arg name="launch_shutdown" default="true" />
   <arg name="launch_edgetpu_human_pose_estimator" default="true" />
   <arg name="launch_edgetpu_object_detector" default="true" />
@@ -341,10 +340,6 @@
       duration: 60
     </rosparam>
   </node>
-
-  <!-- rfcomm_bind -->
-  <include if="$(arg launch_rfcomm_bind)"
-           file="$(find jsk_robot_startup)/launch/rfcomm_bind.launch"/>
 
   <!-- shutdown node -->
   <node if="$(arg launch_shutdown)"

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-rfcomm-bind.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-rfcomm-bind.conf
@@ -3,8 +3,7 @@ command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/mel
 
 stopsignal=TERM
 directory=/home/fetch/ros/melodic
-; autostart=true
-autostart=false
+autostart=true
 autorestart=false
 stdout_logfile=/var/log/ros/jsk-rfcomm-bind.log
 stderr_logfile=/var/log/ros/jsk-rfcomm-bind.log

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-shutdown.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-shutdown.conf
@@ -3,8 +3,7 @@ command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/mel
 
 stopsignal=TERM
 directory=/home/fetch/ros/melodic
-; autostart=true
-autostart=false
+autostart=true
 autorestart=false
 stdout_logfile=/var/log/ros/jsk-shutdown.log
 stderr_logfile=/var/log/ros/jsk-shutdown.log


### PR DESCRIPTION
`rfcomm bind` and `shutdown` commands need to be launched as root.

I add supervisor jobs for these commands with root authority.