### PR TITLE
[jsk_robot_startup] Replace audio/video recorder with rosbag converter in go-to-kitchen demo

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -1,10 +1,16 @@
 # This is rosinstall file for melodic PC inside fetch.
 # $ ln -s $(rospack find jsk_fetch_startup)/../jsk_fetch.rosinstall.$ROS_DISTRO $HOME/ros/$ROS_DISTRO/src/.rosinstall
 
+# Use knorth55 fetch15 branch after the following PR is merged.
+# https://github.com/knorth55/app_manager/pull/2
+# - git:
+#     local-name: PR2/app_manager
+#     uri: https://github.com/knorth55/app_manager.git
+#     version: fetch15
 - git:
     local-name: PR2/app_manager
-    uri: https://github.com/knorth55/app_manager.git
-    version: fetch15 
+    uri: https://github.com/708yamaguchi/app_manager.git
+    version: signal-timeout-fetch15
 - git:
     local-name: RobotWebTools/rosbridge_suite
     uri: https://github.com/RobotWebTools/rosbridge_suite.git
@@ -33,10 +39,16 @@
 #     local-name: jsk-ros-pkg/jsk_common
 #     uri: https://github.com/jsk-ros-pkg/jsk_common.git
 #     version: master
+# Use knorth55 fetch15 branch after the following PR is merged.
+# https://github.com/knorth55/jsk_common/pull/11
+# - git:
+#     local-name: jsk-ros-pkg/jsk_common
+#     uri: https://github.com/knorth55/jsk_common.git
+#     version: fetch15
 - git:
     local-name: jsk-ros-pkg/jsk_common
-    uri: https://github.com/knorth55/jsk_common.git
-    version: fetch15
+    uri: https://github.com/708yamaguchi/jsk_common.git
+    version: rosbag-tools-fetch15
 # we need to use the development branch (fetch15 branch in knorth55's fork)
 # until it is merged to master
 - git:
@@ -64,10 +76,16 @@
     local-name: jsk-ros-pkg/jsk_robot
     uri: https://github.com/knorth55/jsk_robot.git
     version: fetch15
+# Use knorth55 master branch after the following PR is merged.
+# https://github.com/knorth55/app_manager_utils/pull/54
+# - git:
+#     local-name: knorth55/app_manager_utils
+#     uri: https://github.com/knorth55/app_manager_utils
+#     version: master
 - git:
     local-name: knorth55/app_manager_utils
-    uri: https://github.com/knorth55/app_manager_utils
-    version: master
+    uri: https://github.com/708yamaguchi/app_manager_utils
+    version: rosbag-converter
 - git:
     local-name: mikeferguson/robot_calibration
     uri: https://github.com/mikeferguson/robot_calibration.git

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -9,57 +9,6 @@ plugins:
     type: app_notification_saver/service_notification_saver
   - name: smach_notification_saver_plugin
     type: app_notification_saver/smach_notification_saver
-  - name: head_camera_video_recorder_plugin
-    type: app_recorder/audio_video_recorder_plugin
-    launch_args:
-      video_path: /tmp
-      video_title: go_to_kitchen_head_camera.avi
-      audio_topic_name: /audio
-      audio_channels: 1
-      audio_sample_rate: 16000
-      audio_format: wave
-      audio_sample_format: S16LE
-      video_topic_name: /head_camera/rgb/image_rect_color/hz_converted
-      video_height: 480
-      video_width: 640
-      video_framerate: 30
-      video_encoding: RGB
-  - name: object_detection_video_recorder_plugin
-    type: app_recorder/audio_video_recorder_plugin
-    launch_args:
-      video_path: /tmp
-      video_title: go_to_kitchen_object_detection.avi
-      audio_topic_name: /audio
-      audio_channels: 1
-      audio_sample_rate: 16000
-      audio_format: wave
-      audio_sample_format: S16LE
-      video_topic_name: /edgetpu_object_detector/output/image/hz_converted
-      video_height: 480
-      video_width: 640
-      video_framerate: 30
-      video_encoding: RGB
-  - name: panorama_video_recorder_plugin
-    type: app_recorder/video_recorder_plugin
-    launch_args:
-      video_path: /tmp
-      video_title: go_to_kitchen_panorama.avi
-      video_topic_name: /dual_fisheye_to_panorama/output
-      video_fps: 1.0
-  - name: rviz_video_recorder_plugin
-    type: app_recorder/video_recorder_plugin
-    launch_args:
-      video_path: /tmp
-      video_title: go_to_kitchen_rviz.avi
-      video_topic_name: /rviz/image
-      video_fps: 30.0
-  - name: respeaker_audio_recorder_plugin
-    type: app_recorder/audio_recorder_plugin
-    launch_args:
-      audio_path: /tmp
-      audio_title: go_to_kitchen_audio.wav
-      audio_topic_name: /audio
-      audio_format: wave
   - name: rosbag_recorder_plugin
     type: app_recorder/rosbag_recorder_plugin
     launch_args:
@@ -86,15 +35,64 @@ plugins:
         - /move_base/global_costmap/costmap
         - /particlecloud
         - /base_scan/throttled
+        - /dual_fisheye_to_panorama/quater/output/compressed
+        - /edgetpu_object_detector/output/image/compressed
         - /head_camera/rgb/throttled/camera_info
         - /head_camera/depth_registered/throttled/camera_info
         - /head_camera/rgb/throttled/image_rect_color/compressed
         - /head_camera/depth_registered/throttled/image_rect/compressedDepth
+        - /rviz/image/compressed
         - /server_name/smach/container_init
         - /server_name/smach/container_status
         - /server_name/smach/container_structure
         - /audio
-        - /dual_fisheye_to_panorama/quater/output
+  - name: head_camera_converter_plugin
+    type: app_recorder/rosbag_video_converter_plugin
+    plugin_args:
+      rosbag_path: /tmp
+      rosbag_title: go_to_kitchen_rosbag.bag
+      image_topic_name: /head_camera/rgb/throttled/image_rect_color/compressed
+      image_fps: 5
+      audio_topic_name: /audio
+      audio_sample_rate: 16000
+      audio_channels: 1
+      video_path: /tmp/go_to_kitchen_head_camera.mp4
+  - name: object_detection_converter_plugin
+    type: app_recorder/rosbag_video_converter_plugin
+    plugin_args:
+      rosbag_path: /tmp
+      rosbag_title: go_to_kitchen_rosbag.bag
+      image_topic_name: /edgetpu_object_detector/output/image/compressed
+      image_fps: 30
+      audio_topic_name: /audio
+      audio_sample_rate: 16000
+      audio_channels: 1
+      video_path: /tmp/go_to_kitchen_object_detection.mp4
+  - name: panorama_converter_plugin
+    type: app_recorder/rosbag_video_converter_plugin
+    plugin_args:
+      rosbag_path: /tmp
+      rosbag_title: go_to_kitchen_rosbag.bag
+      image_topic_name: /dual_fisheye_to_panorama/quater/output/compressed
+      image_fps: 1
+      video_path: /tmp/go_to_kitchen_panorama.mp4
+  - name: rviz_converter_plugin
+    type: app_recorder/rosbag_video_converter_plugin
+    plugin_args:
+      rosbag_path: /tmp
+      rosbag_title: go_to_kitchen_rosbag.bag
+      image_topic_name: /rviz/image/compressed
+      image_fps: 30
+      video_path: /tmp/go_to_kitchen_rviz.mp4
+  - name: respeaker_audio_converter_plugin
+    type: app_recorder/rosbag_audio_converter_plugin
+    plugin_args:
+      rosbag_path: /tmp
+      rosbag_title: go_to_kitchen_rosbag.bag
+      audio_topic_name: /audio
+      audio_sample_rate: 16000
+      audio_channels: 1
+      audio_path: /tmp/go_to_kitchen_audio.wav
   - name: result_recorder_plugin
     type: app_recorder/result_recorder_plugin
     plugin_args:
@@ -105,19 +103,19 @@ plugins:
     plugin_args:
       upload_file_paths:
         - /tmp/go_to_kitchen_result.yaml
-        - /tmp/go_to_kitchen_head_camera.avi
-        - /tmp/go_to_kitchen_object_detection.avi
-        - /tmp/go_to_kitchen_panorama.avi
-        - /tmp/go_to_kitchen_rviz.avi
+        - /tmp/go_to_kitchen_head_camera.mp4
+        - /tmp/go_to_kitchen_object_detection.mp4
+        - /tmp/go_to_kitchen_panorama.mp4
+        - /tmp/go_to_kitchen_rviz.mp4
         - /tmp/go_to_kitchen_audio.wav
         - /tmp/go_to_kitchen_rosbag.bag
         - /tmp/trashcan_inside.jpg
       upload_file_titles:
         - go_to_kitchen_result.yaml
-        - go_to_kitchen_head_camera.avi
-        - go_to_kitchen_object_detection.avi
-        - go_to_kitchen_panorama.avi
-        - go_to_kitchen_rviz.avi
+        - go_to_kitchen_head_camera.mp4
+        - go_to_kitchen_object_detection.mp4
+        - go_to_kitchen_panorama.mp4
+        - go_to_kitchen_rviz.mp4
         - go_to_kitchen_audio.wav
         - go_to_kitchen_rosbag.bag
         - trashcan_inside.jpg
@@ -162,12 +160,12 @@ plugin_order:
     - move_base_cancel_plugin
     - service_notification_saver_plugin
     - smach_notification_saver_plugin
-    - head_camera_video_recorder_plugin
-    - object_detection_video_recorder_plugin
-    - panorama_video_recorder_plugin
-    - rviz_video_recorder_plugin
-    - respeaker_audio_recorder_plugin
     - rosbag_recorder_plugin
+    - head_camera_converter_plugin
+    - object_detection_converter_plugin
+    - panorama_converter_plugin
+    - rviz_converter_plugin
+    - respeaker_audio_converter_plugin
     - result_recorder_plugin
     - gdrive_uploader_plugin
     - tweet_notifier_plugin
@@ -178,12 +176,12 @@ plugin_order:
     - move_base_cancel_plugin
     - service_notification_saver_plugin
     - smach_notification_saver_plugin
-    - head_camera_video_recorder_plugin
-    - object_detection_video_recorder_plugin
-    - panorama_video_recorder_plugin
-    - rviz_video_recorder_plugin
-    - respeaker_audio_recorder_plugin
     - rosbag_recorder_plugin
+    - head_camera_converter_plugin
+    - object_detection_converter_plugin
+    - panorama_converter_plugin
+    - rviz_converter_plugin
+    - respeaker_audio_converter_plugin
     - result_recorder_plugin
     - gdrive_uploader_plugin
     - tweet_notifier_plugin

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
@@ -7,27 +7,6 @@
     <param name="score_thresh" type="double" value="0.60" /> <!-- default: 0.6 -->
   </node>
 
-  <!-- Image topic hz converter for better synchronization betweeen audio and video-->
-  <node name="head_camera_image_hz_converter"
-        pkg="jsk_topic_tools"
-        type="topic_hz_converter.py">
-    <remap from="~input" to="/head_camera/rgb/image_rect_color" />
-    <remap from="~output" to="/head_camera/rgb/image_rect_color/hz_converted" />
-    <rosparam>
-      desired_topic_hz: 30
-    </rosparam>
-  </node>
-
-  <node name="object_detect_image_hz_converter"
-        pkg="jsk_topic_tools"
-        type="topic_hz_converter.py">
-    <remap from="~input" to="/edgetpu_object_detector/output/image" />
-    <remap from="~output" to="/edgetpu_object_detector/output/image/hz_converted" />
-    <rosparam>
-      desired_topic_hz: 30
-    </rosparam>
-  </node>
-
   <!-- Use m5stack_ros -->
   <!-- See https://github.com/jsk-ros-pkg/jsk_3rdparty/pull/289 -->
   <node name="rosserial_m5stack" pkg="rosserial_python" type="serial_node.py">

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -133,6 +133,7 @@
     <arg name="respawn" value="false" />
     <arg name="basic" value="true" />
     <arg name="basic_yaml" value="/var/lib/robot/roswww_basic_keys.yaml" />
+    <arg name="sigint_timeout" value="120.0" />
   </include>
 
   <!-- app scheduler -->

--- a/jsk_robot_common/jsk_robot_startup/lifelog/app_manager.launch
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/app_manager.launch
@@ -2,6 +2,8 @@
   <arg name="master" default="true" doc="launch master if enabled"/>
   <arg name="master_address" default="localhost" doc="address for app_manager master"/>
   <arg name="master_port" default="11313" doc="port for app_manager master"/>
+  <arg name="sigint_timeout" default="15.0" doc="Time between sending sigint and sending sigterm to ROSLaunchParent"/>
+  <arg name="sigterm_timeout" default="2.0" doc="Time between sending sigterm and sending sigkill to ROSLaunchParent"/>
 
   <arg name="use_applist" default="false" doc="load apps from applist argument"/>
   <arg name="applist" default="" doc="app dirs (space separated)"/>
@@ -64,6 +66,8 @@
     <arg name="master" value="$(arg master)"/>
     <arg name="master_address" value="$(arg master_address)"/>
     <arg name="master_port" value="$(arg master_port)"/>
+    <arg name="sigint_timeout" value="$(arg sigint_timeout)"/>
+    <arg name="sigterm_timeout" value="$(arg sigterm_timeout)"/>
     <arg name="use_applist" value="$(arg use_applist)"/>
     <arg name="applist" value="$(arg applist)"/>
     <arg name="respawn" value="$(arg respawn)"/>


### PR DESCRIPTION
With this PR, we can generate video files from rosbag after the go-to-kitchen demo.
I this case, we do not have to generate the video files while the demo is running.
This can reduce CPU usage during the demo compared to audio_video_recorder.

Related to https://github.com/knorth55/app_manager/pull/2, https://github.com/knorth55/app_manager_utils/pull/54 and https://github.com/knorth55/jsk_common/pull/11

I currently uses 708yamaguchi branches in `jsk_fetch.rosinstall.melodic`
If the above PRs work well, I will replace the 708yamaguchi branches with the knorth55 branches.