### PR TITLE
[jsk_fetch_startup] Use knorth55 fetch15 branch for jsk_common

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -39,16 +39,10 @@
 #     local-name: jsk-ros-pkg/jsk_common
 #     uri: https://github.com/jsk-ros-pkg/jsk_common.git
 #     version: master
-# Use knorth55 fetch15 branch after the following PR is merged.
-# https://github.com/knorth55/jsk_common/pull/11
-# - git:
-#     local-name: jsk-ros-pkg/jsk_common
-#     uri: https://github.com/knorth55/jsk_common.git
-#     version: fetch15
 - git:
     local-name: jsk-ros-pkg/jsk_common
-    uri: https://github.com/708yamaguchi/jsk_common.git
-    version: rosbag-tools-fetch15
+    uri: https://github.com/knorth55/jsk_common.git
+    version: fetch15
 # we need to use the development branch (fetch15 branch in knorth55's fork)
 # until it is merged to master
 - git:

--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -70,16 +70,10 @@
     local-name: jsk-ros-pkg/jsk_robot
     uri: https://github.com/knorth55/jsk_robot.git
     version: fetch15
-# Use knorth55 master branch after the following PR is merged.
-# https://github.com/knorth55/app_manager_utils/pull/54
-# - git:
-#     local-name: knorth55/app_manager_utils
-#     uri: https://github.com/knorth55/app_manager_utils
-#     version: master
 - git:
     local-name: knorth55/app_manager_utils
-    uri: https://github.com/708yamaguchi/app_manager_utils
-    version: rosbag-converter
+    uri: https://github.com/knorth55/app_manager_utils
+    version: master
 - git:
     local-name: mikeferguson/robot_calibration
     uri: https://github.com/mikeferguson/robot_calibration.git


### PR DESCRIPTION
Reset source branch in `jsk_fetch.rosinstall.melodic` because the following PRs are merged.

https://github.com/knorth55/jsk_common/pull/11
https://github.com/knorth55/app_manager_utils/pull/54