### PR TITLE
Add poke() to correct_position.py to avoid diagnostics error

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -242,7 +242,11 @@
     </include>
 
     <!-- dock localization -->
-    <node pkg="jsk_fetch_startup" type="correct_position.py" name="correct_position" respawn="true" />
+    <node pkg="jsk_fetch_startup" type="correct_position.py" name="correct_position" respawn="true">
+      <rosparam>
+        vital_rate: 0.1
+      </rosparam>
+    </node>
 
     <!-- include fetch_navigation -->
     <include file="$(find fetch_navigation)/launch/fetch_nav.launch" unless="$(arg use_build_map)" >

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/correct_position.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/correct_position.py
@@ -38,6 +38,7 @@ class CorrectPosition(ConnectionBasedTransport):
         self.sub_dock.unregister()
 
     def _cb(self, msg):
+        self.poke()
         self.is_docking = msg.is_charging
 
     def _cb_correct_position(self, event):

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/correct_position.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/correct_position.py
@@ -2,20 +2,20 @@
 
 import rospy
 
+from jsk_topic_tools import ConnectionBasedTransport
 from power_msgs.msg import BatteryState
 from geometry_msgs.msg import PoseWithCovarianceStamped
 from geometry_msgs.msg import Pose
 from visualization_msgs.msg import MarkerArray
 
 
-class CorrectPosition():
+class CorrectPosition(ConnectionBasedTransport):
 
     def __init__(self):
-        self.sub_dock = rospy.Subscriber(
-            '/battery_state', BatteryState, self._cb)
-        self.pub = rospy.Publisher('initialpose',
-                                   PoseWithCovarianceStamped,
-                                   queue_size=1)
+        super(CorrectPosition, self).__init__()
+        self.pub = self.advertise('initialpose',
+                                  PoseWithCovarianceStamped,
+                                  queue_size=1)
         self.dock_pose = Pose()
         robot_name = rospy.get_param('/robot/name')
         if robot_name == 'fetch15':
@@ -29,6 +29,13 @@ class CorrectPosition():
 
         self.is_docking = False
         self.timer = rospy.Timer(rospy.Duration(1.0), self._cb_correct_position)
+
+    def subscribe(self):
+        self.sub_dock = rospy.Subscriber(
+            '/battery_state', BatteryState, self._cb)
+
+    def unsubscribe(self):
+        self.sub_dock.unregister()
 
     def _cb(self, msg):
         self.is_docking = msg.is_charging


### PR DESCRIPTION
Depends on https://github.com/jsk-ros-pkg/jsk_common/pull/1740

In `correct_position.py`, fetch publishes `initialpose` topic to `amcl` node when the following 2 conditions are met.
- `initialpose` topic is subscribed by `amcl`
- fetch is docking

I this case, even if `initialpose` is subscribed, it does not necessarily mean that publish is performed.
So I manually call `poke()` in callback function in addition to  `publish()`.

cc @iory @knorth55 