### PR TITLE
[jsk_fetch_startup] Remove NETWORK_DEFAULT_ROS_INTERFACE

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/README.md
+++ b/jsk_fetch_robot/jsk_fetch_startup/README.md
@@ -85,16 +85,12 @@ descriptions of each variable are below.
   + Wi-Fi network interface for network management scripts (e.g. `network_monitor.py` and `network-log-wifi.sh`)
 - `NETWORK_DEFAULT_PROFILE_ID`
   + Network manager profile ID for network management scripts (`network_monitor.py`)
-+ `NETWORK_DEFAULT_ROS_INTERFACE`
-  + Network interface or IP address which is used for ROS connection.
-  + `rossetip $NETWORK_DEFAULT_ROS_INTERFACE` is executed to set `ROS_IP`.
 
 It is also recommended to add lines below to each users's bashrc in the robot PC.
 
 ```bash
 source /var/lib/robot/config.bash
 rossetmaster localhost
-rossetip $NETWORK_DEFAULT_ROS_INTERFACE
 ```
 
 ### supervisor

--- a/jsk_fetch_robot/jsk_fetch_startup/config/config.bash
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/config.bash
@@ -20,7 +20,6 @@ if [ $(hostname) = 'fetch15' ]; then
   export RS_SERIAL_NO_L515_HEAD="";
 
   export NETWORK_DEFAULT_WIFI_INTERFACE="wlan0";
-  export NETWORK_DEFAULT_ROS_INTERFACE="localhost";
   export NETWORK_DEFAULT_PROFILE_ID="sanshiro-73B2";
 elif [ $(hostname) = 'fetch1075' ]; then
   export DEFAULT_SPEAKER=2;
@@ -41,6 +40,5 @@ elif [ $(hostname) = 'fetch1075' ]; then
   export RS_SERIAL_NO_L515_HEAD="";
 
   export NETWORK_DEFAULT_WIFI_INTERFACE="wlan1";
-  export NETWORK_DEFAULT_ROS_INTERFACE="localhost";
   export NETWORK_DEFAULT_PROFILE_ID="sanshiro-73B2";
 fi

--- a/jsk_fetch_robot/jsk_fetch_startup/config/config_outside.bash
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/config_outside.bash
@@ -7,6 +7,5 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && 
 if [ $(hostname) = 'fetch15' ]; then
   export NETWORK_DEFAULT_PROFILE_ID="sanshiro-outside";
 elif [ $(hostname) = 'fetch1075' ]; then
-  export NETWORK_DEFAULT_ROS_INTERFACE="wlan0";
   export NETWORK_DEFAULT_PROFILE_ID="sanshiro-outside";
 fi


### PR DESCRIPTION
According to https://github.com/knorth55/jsk_robot/pull/253#discussion_r889693691, https://github.com/knorth55/jsk_robot/pull/253#discussion_r889693787 and https://github.com/knorth55/jsk_robot/pull/253#discussion_r889695847, remove `NETWORK_DEFAULT_ROS_INTERFACE`.

@iory @knorth55 @sktometometo 