### PR TITLE
Fetch15 hz measure diagnostics

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/config/fetch_analyzers.yaml
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/fetch_analyzers.yaml
@@ -102,7 +102,7 @@ analyzers:
         path: Head Camera
         timeout: 5.0
         startswith: 'head_camera'
-        num_items: 2
+        num_items: 4
       imu:
         type: diagnostic_aggregator/GenericAnalyzer
         path: IMU
@@ -152,18 +152,6 @@ analyzers:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Audio
         contains: '/audio'
-        timeout: 100
-        discard_stale: true
-      head_depth_image:
-        type: diagnostic_aggregator/GenericAnalyzer
-        path: HeadDepthImage
-        contains: '/head_camera/depth/image_raw'
-        timeout: 100
-        discard_stale: true
-      head_rgb_image:
-        type: diagnostic_aggregator/GenericAnalyzer
-        path: HeadRGBImage
-        contains: '/head_camera/rgb/image_raw'
         timeout: 100
         discard_stale: true
   nodes:

--- a/jsk_fetch_robot/jsk_fetch_startup/config/sanity_targets.yaml
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/sanity_targets.yaml
@@ -2,8 +2,6 @@ topics:
   - /audio
   - /edgetpu_human_pose_estimator/output/image/compressed
   - /edgetpu_object_detector/output/image/compressed
-  - /head_camera/depth/image_raw
-  - /head_camera/rgb/image_raw
 
 nodes:
   - /head_camera/head_camera_nodelet_manager

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -105,7 +105,8 @@
 
   <!-- diagnostic aggregator -->
   <node pkg="diagnostic_aggregator" type="aggregator_node"
-        name="diag_agg" args="CPP" output="screen" >
+        name="diag_agg" args="CPP" output="screen"
+        clear_params="true" >
     <rosparam command="load" file="$(find jsk_fetch_startup)/config/fetch_analyzers.yaml" />
   </node>
 

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -338,7 +338,8 @@
   </node>
 
   <!-- Publish /diagnostics based on topics and nodes sanity check -->
-  <node name="sanity_diagnostics" pkg="jsk_tools" type="sanity_diagnostics.py">
+  <node name="sanity_diagnostics" pkg="jsk_tools" type="sanity_diagnostics.py"
+        clear_params="true" >
     <rosparam command="load" file="$(find jsk_fetch_startup)/config/sanity_targets.yaml" />
     <rosparam subst_value="true">
       duration: 60

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_sensors.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_sensors.xml
@@ -16,6 +16,15 @@
 
   <group ns="head_camera">
     <group ns="depth_registered">
+      <node name="hz_measure"
+            pkg="nodelet" type="nodelet"
+            args="load jsk_topic_tools/HzMeasure /$(arg manager)" >
+        <remap from="~input" to="hw_registered/image_rect_raw" />
+        <remap from="~output" to="hw_registered/image_rect_raw/measured_hz" />
+        <rosparam subst_value="true" >
+          warning_hz: 5
+        </rosparam>
+      </node>
       <node name="resize_cloud"
             pkg="nodelet" type="nodelet"
             args="load jsk_pcl/ResizePointsPublisher /$(arg manager)"
@@ -81,6 +90,15 @@
     </group>
     <group ns="rgb"
            if="$(arg throttle_head_rgb)">
+      <node name="hz_measure"
+            pkg="nodelet" type="nodelet"
+            args="load jsk_topic_tools/HzMeasure /$(arg manager)" >
+        <remap from="~input" to="image_raw" />
+        <remap from="~output" to="image_raw/measured_hz" />
+        <rosparam subst_value="true" >
+          warning_hz: 5
+        </rosparam>
+      </node>
       <node name="throttle_camera_info"
             pkg="nodelet" type="nodelet"
             args="load jsk_topic_tools/LightweightThrottle /$(arg manager)"


### PR DESCRIPTION
# What is this?

Enable publishing rgb/depth diagnostics using `HzMeasureNodelet`.
The difference from `sanity_diagnostics.py` is that we can ignore the communication overhead when using it with nodelet.
This PR needs the following PR.
https://github.com/knorth55/jsk_common/pull/16

cc: @708yamaguchi @tkmtnt7000