### PR TITLE
[jsk_fetch_startup] Wait for a certain time in get-battery-charge-state

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -143,14 +143,19 @@
   ;; while dock succeeds, the result will not be correct,
   ;; so wait for a certain time when docking.
   """
-  (let ((msg nil)
-        (is-charging nil)
-        (duration 0)
-        (start-time (send (ros::time-now) :sec)))
-    (while (and (< duration timeout) (not is-charging))
-      (setq msg (one-shot-subscribe "/battery_state" power_msgs::BatteryState))
+  (let* ((msg nil)
+         (is-charging nil)
+         (duration 0)
+         (start-time (send (ros::time-now) :sec)))
+    (while (not is-charging)
+      (when (> duration timeout)
+        (ros::ros-warn "Skip waiting for charging state because of timeout")
+        (return-from wait-until-is-charging :timeout))
+      (setq msg (one-shot-subscribe "/battery_state" power_msgs::BatteryState
+                                    :timeout 1000))
       (if msg (setq is-charging (send msg :is_charging)))
-      (setq duration (- (send (ros::time-now) :sec) start-time)))))
+      (setq duration (- (send (ros::time-now) :sec) start-time)))
+    :charging))
 
 (defun get-battery-charging-state (&key (timeout 1500))
   """

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -132,7 +132,7 @@
     (return-from undock nil))
   (send (send *undock-action* :get-result) :undocked))
 
-(defun wait-until-is-charging (&key timeout 10)
+(defun wait-until-is-charging (&key (timeout 10))
   """
   Wait for updating battery charging state especially when robots dock.
   Args:
@@ -541,7 +541,7 @@
     (restore-params)
     (send-kitchen-mail)
     (setq success-battery-charging (progn (wait-until-is-charging)
-                                          (equal (get-battery-charging-state) :charging))
+                                          (equal (get-battery-charging-state) :charging)))
     (and success-go-to-kitchen success-auto-dock success-battery-charging)))
 
 

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -132,34 +132,39 @@
     (return-from undock nil))
   (send (send *undock-action* :get-result) :undocked))
 
+(defun wait-until-is-charging (&key timeout 10)
+  """
+  Wait for updating battery charging state especially when robots dock.
+  Args:
+    - key
+      timeout [sec]: Set waiting time for updating /battery_state topic
 
-(defun get-battery-charging-state (&key (timeout 1500) (dock nil))
+  ;; If /battery_state is subscribed before /battery_state becomes true
+  ;; while dock succeeds, the result will not be correct,
+  ;; so wait for a certain time when docking.
+  """
+  (let ((msg nil)
+        (is-charging nil)
+        (duration 0)
+        (start-time (send (ros::time-now) :sec)))
+    (while (and (< duration timeout) (not is-charging))
+      (setq msg (one-shot-subscribe "/battery_state" power_msgs::BatteryState))
+      (if msg (setq is-charging (send msg :is_charging)))
+      (setq duration (- (send (ros::time-now) :sec) start-time)))))
+
+(defun get-battery-charging-state (&key (timeout 1500))
   """
   Get battery charging state
   Args:
     - key
       timeout: Set waiting time for topic.
-      dock: Set t when docking to get right result.
   """
    (let* ((msg (one-shot-subscribe "/battery_state" power_msgs::batterystate :timeout timeout))
-          (is-charging (if msg (send msg :is_charging)))
-          (start-get-state-time (send (ros::time-now) :sec))
-          (duration 0))
+          (is-charging (if msg (send msg :is_charging))))
      ;; You may fail to subscribe /battery_state
      ;; because of message md5 difference between melodic and indigo.
-     ;; If /battery_state is subscribed before /battery_state becomes true
-     ;; while dock succeeds, the result will not be correct,
-     ;; so wait for a certain time when docking.
-     (when dock
-       (while (and (< duration (/ timeout 1000)) (not is-charging))
-         (setq msg (one-shot-subscribe "/battery_state"
-                                       power_msgs::BatteryState
-                                       :timeout timeout))
-         (if msg (setq is-charging (send msg :is_charging)))
-         (setq duration (- (send (ros::time-now) :sec) start-get-state-time))))
      (if (not msg) (return-from get-battery-charging-state nil))
      (if is-charging :charging :discharging)))
-
 
 (defun go-to-spot (name &key (relative-pos nil) (relative-rot nil) (undock-rotate nil) (clear-costmap t))
   ;; undock if fetch is docking
@@ -535,7 +540,8 @@
     ;; change the inflation_radius
     (restore-params)
     (send-kitchen-mail)
-    (setq success-battery-charging (equal (get-battery-charging-state :dock t) :charging))
+    (setq success-battery-charging (progn (wait-until-is-charging)
+                                          (equal (get-battery-charging-state) :charging))
     (and success-go-to-kitchen success-auto-dock success-battery-charging)))
 
 
@@ -640,7 +646,8 @@
             (:finish
               '(lambda (userdata)
                  (let ((success-battery-charging
-                         (equal (get-battery-charging-state :dock t) :charging))
+                        (progn (wait-until-is-charging)
+                               (equal (get-battery-charging-state) :charging)))
                        (success-auto-dock (cdr (assoc 'success-auto-dock userdata)))
                        (success-go-to-kitchen
                          (cdr (assoc 'success-go-to-kitchen userdata))))

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -133,11 +133,30 @@
   (send (send *undock-action* :get-result) :undocked))
 
 
-(defun get-battery-charging-state (&key (timeout 1500))
+(defun get-battery-charging-state (&key (timeout 1500) (dock nil))
+  """
+  Get battery charging state
+  Args:
+    - key
+      timeout: Set waiting time for topic.
+      dock: Set t when docking to get right result.
+  """
    (let* ((msg (one-shot-subscribe "/battery_state" power_msgs::batterystate :timeout timeout))
-          (is-charging (if msg (send msg :is_charging))))
+          (is-charging (if msg (send msg :is_charging)))
+          (start-get-state-time (send (ros::time-now) :sec))
+          (duration 0))
      ;; You may fail to subscribe /battery_state
      ;; because of message md5 difference between melodic and indigo.
+     ;; If /battery_state is subscribed before /battery_state becomes true
+     ;; while dock succeeds, the result will not be correct,
+     ;; so wait for a certain time when docking.
+     (when dock
+       (while (and (< duration (/ timeout 1000)) (not is-charging))
+         (setq msg (one-shot-subscribe "/battery_state"
+                                       power_msgs::BatteryState
+                                       :timeout timeout))
+         (if msg (setq is-charging (send msg :is_charging)))
+         (setq duration (- (send (ros::time-now) :sec) start-get-state-time))))
      (if (not msg) (return-from get-battery-charging-state nil))
      (if is-charging :charging :discharging)))
 
@@ -516,7 +535,7 @@
     ;; change the inflation_radius
     (restore-params)
     (send-kitchen-mail)
-    (setq success-battery-charging (equal (get-battery-charging-state) :charging))
+    (setq success-battery-charging (equal (get-battery-charging-state :dock t) :charging))
     (and success-go-to-kitchen success-auto-dock success-battery-charging)))
 
 
@@ -621,12 +640,12 @@
             (:finish
               '(lambda (userdata)
                  (let ((success-battery-charging
-                         (equal (get-battery-charging-state) :charging))
+                         (equal (get-battery-charging-state :dock t) :charging))
                        (success-auto-dock (cdr (assoc 'success-auto-dock userdata)))
                        (success-go-to-kitchen
                          (cdr (assoc 'success-go-to-kitchen userdata))))
                    (restore-params)
-		   (send-kitchen-mail)
+                   (send-kitchen-mail)
                    (and success-go-to-kitchen success-auto-dock success-battery-charging)))))
           '(:init)
           '(t nil))))


### PR DESCRIPTION
In a recent morning kitchen demo, the demo was marked as fail because the battery charging state was obtained wrongly.
To avoid this, after docking the demo waits for a certain period of time to exit from the `get-battery-charging-state` until it is judged to have started charging.