### PR TITLE
Pr/fetchdev/make args to be load with optenv

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -12,9 +12,9 @@
   <arg name="launch_edgetpu_object_detector" default="true" />
 
   <arg name="use_voice_text" default="false" />
-  <arg name="default_speaker" default="$(OPTENV DEFAULT_SPEAKER_ 2)" />
-  <arg name="default_english_speaker" default="$(OPTENV DEFAULT_ENGLISH_SPEAKER kal)" />
-  <arg name="default_warning_speaker" default="$(OPTENV DEFAULT_ENGLISH_SPEAKER kal)" />
+  <arg name="default_speaker" default="$(optenv DEFAULT_SPEAKER 2)" />
+  <arg name="default_english_speaker" default="$(optenv DEFAULT_ENGLISH_SPEAKER kal)" />
+  <arg name="default_warning_speaker" default="$(optenv DEFAULT_ENGLISH_SPEAKER kal)" />
   <arg name="fetch_lifelog" default="true" />
   <arg name="boot_sound" default="true" />
   <arg name="map_frame" default="eng2" />
@@ -22,7 +22,7 @@
   <arg name="keepout_map_file" default="$(find jsk_maps)/raw_maps/eng2-7f-0.05_keepout.yaml" />
   <arg name="use_build_map" default="false" />
   <arg name="use_keepout" default="true" />
-  <arg name="network_interface" default="$(OPTENV NETWORK_DEFAULT_WIFI_INTERFACE wlan0)" />
+  <arg name="network_interface" default="$(optenv NETWORK_DEFAULT_WIFI_INTERFACE wlan0)" />
 
   <arg name="battery_warning" default="true" />
   <arg name="nav_speak" default="true" />

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -12,17 +12,17 @@
   <arg name="launch_edgetpu_object_detector" default="true" />
 
   <arg name="use_voice_text" default="false" />
-  <arg name="default_speaker" default="2" />
-  <arg name="default_english_speaker" default="kal" />
-  <arg name="default_warning_speaker" default="kal" />
+  <arg name="default_speaker" default="$(OPTENV DEFAULT_SPEAKER_ 2)" />
+  <arg name="default_english_speaker" default="$(OPTENV DEFAULT_ENGLISH_SPEAKER kal)" />
+  <arg name="default_warning_speaker" default="$(OPTENV DEFAULT_ENGLISH_SPEAKER kal)" />
   <arg name="fetch_lifelog" default="true" />
-  <arg name="boot_sound" default="false" />
+  <arg name="boot_sound" default="true" />
   <arg name="map_frame" default="eng2" />
   <arg name="map_file" default="$(find jsk_maps)/raw_maps/eng2-7f-0.05.yaml"/>
   <arg name="keepout_map_file" default="$(find jsk_maps)/raw_maps/eng2-7f-0.05_keepout.yaml" />
   <arg name="use_build_map" default="false" />
   <arg name="use_keepout" default="true" />
-  <arg name="network_interface" default="wlan0" />
+  <arg name="network_interface" default="$(OPTENV NETWORK_DEFAULT_WIFI_INTERFACE wlan0)" />
 
   <arg name="battery_warning" default="true" />
   <arg name="nav_speak" default="true" />
@@ -34,6 +34,7 @@
   <arg name="network_detector" default="true" />
   <arg name="network_status" default="true" />
   <arg name="use_speech_recognition" default="true" />
+  <arg name="use_audible_warning" default="true" />
 
   <param name="robot/type" value="fetch" />
   <param name="robot/name" command='bash -c "hostname | xargs echo -n"' />
@@ -337,7 +338,8 @@
   <node name="audible_warning"
         pkg="jsk_tools" type="audible_warning.py"
         clear_params="true"
-        output="screen" >
+        output="screen"
+        if="$(arg use_audible_warning)" >
     <remap from="/robotsound" to="/sound_play" />
     <rosparam command="load" file="$(find jsk_fetch_startup)/config/warning_blacklist.yaml" />
     <rosparam subst_value="true">

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-fetch-startup.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-fetch-startup.conf
@@ -1,5 +1,5 @@
 [program:jsk-fetch-startup]
-command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && . /home/fetch/eus10_ws/devel/setup.bash && if [ -e /var/lib/robot/config.bash ];then . /var/lib/robot/config.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && export ROS_HOSTNAME=$(hostname) && rosrun jsk_fetch_startup setup_audio.bash && roslaunch jsk_fetch_startup fetch_bringup.launch hostname:=$(hostname) boot_sound:=true default_speaker:=$DEFAULT_SPEAKER default_english_speaker:=$DEFAULT_ENGLISH_SPEAKER default_warning_speaker:=$DEFAULT_WARNING_SPEAKER network_interface:=$NETWORK_DEFAULT_WIFI_INTERFACE --wait"
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && . /home/fetch/eus10_ws/devel/setup.bash && if [ -e /var/lib/robot/config.bash ];then . /var/lib/robot/config.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && export ROS_HOSTNAME=$(hostname) && rosrun jsk_fetch_startup setup_audio.bash && roslaunch jsk_fetch_startup fetch_bringup.launch hostname:=$(hostname) --wait"
 stopsignal=TERM
 directory=/home/fetch/ros/melodic
 autostart=true


### PR DESCRIPTION
This PR make some args to be loaded in roslaunch xml with optenv instead of giving them as command line args in supervisor jobs.
This is useful if you want to run fetch_bringup.launch from command line.

and add use_audible_warning arg