### PR TITLE
Add ros interface environment variable

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -39,6 +39,7 @@
     version: fetch15
 # we need to use the development branch until PR below are merged.
 #  - https://github.com/jsk-ros-pkg/jsk_common/pull/1719
+#  - https://github.com/jsk-ros-pkg/jsk_common/pull/1746
 # Waiting 2.2.12 release
 # - git:
 #     local-name: jsk-ros-pkg/jsk_common

--- a/jsk_fetch_robot/jsk_fetch_startup/README.md
+++ b/jsk_fetch_robot/jsk_fetch_startup/README.md
@@ -85,8 +85,8 @@ descriptions of each variable are below.
 - `NETWORK_DEFAULT_PROFILE_ID`
   + Network manager profile ID for network management scripts (`network_monitor.py`)
 + `NETWORK_DEFAULT_ROS_INTERFACE`
-  + Network interface or IP address which is used for ROS connection.
-  + `rossetip $NETWORK_DEFAULT_ROS_INTERFACE` is executed to set `ROS_IP`.
+  + Network interface or IP address or hostname which is used for ROS connection.
+  + `rossetclient $NETWORK_DEFAULT_ROS_INTERFACE` is executed to set `ROS_IP`.
 
 It is also recommended to add lines below to each users's bashrc in the robot PC.
 

--- a/jsk_fetch_robot/jsk_fetch_startup/README.md
+++ b/jsk_fetch_robot/jsk_fetch_startup/README.md
@@ -86,7 +86,7 @@ descriptions of each variable are below.
   + Network manager profile ID for network management scripts (`network_monitor.py`)
 + `NETWORK_DEFAULT_ROS_INTERFACE`
   + Network interface or IP address or hostname which is used for ROS connection.
-  + `rossetclient $NETWORK_DEFAULT_ROS_INTERFACE` is executed to set `ROS_IP`.
+  + `rossetclient $NETWORK_DEFAULT_ROS_INTERFACE` is executed to set `ROS_IP` or `ROS_HOSTNAME`.
 
 It is also recommended to add lines below to each users's bashrc in the robot PC.
 

--- a/jsk_fetch_robot/jsk_fetch_startup/README.md
+++ b/jsk_fetch_robot/jsk_fetch_startup/README.md
@@ -84,12 +84,16 @@ descriptions of each variable are below.
   + Wi-Fi network interface for network management scripts (e.g. `network_monitor.py` and `network-log-wifi.sh`)
 - `NETWORK_DEFAULT_PROFILE_ID`
   + Network manager profile ID for network management scripts (`network_monitor.py`)
++ `NETWORK_DEFAULT_ROS_INTERFACE`
+  + Network interface or IP address which is used for ROS connection.
+  + `rossetip $NETWORK_DEFAULT_ROS_INTERFACE` is executed to set `ROS_IP`.
 
 It is also recommended to add lines below to each users's bashrc in the robot PC.
 
 ```bash
 source /var/lib/robot/config.bash
 rossetmaster localhost
+rossetip $NETWORK_DEFAULT_ROS_INTERFACE
 ```
 
 ### supervisor

--- a/jsk_fetch_robot/jsk_fetch_startup/config/config.bash
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/config.bash
@@ -20,7 +20,7 @@ if [ $(hostname) = 'fetch15' ]; then
   export RS_SERIAL_NO_L515_HEAD="";
 
   export NETWORK_DEFAULT_WIFI_INTERFACE="wlan0";
-  export NETWORK_DEFAULT_ROS_INTERFACE="localhost";
+  export NETWORK_DEFAULT_ROS_INTERFACE="fetch15";
   export NETWORK_DEFAULT_PROFILE_ID="sanshiro-73B2";
 elif [ $(hostname) = 'fetch1075' ]; then
   export DEFAULT_SPEAKER=2;
@@ -41,6 +41,6 @@ elif [ $(hostname) = 'fetch1075' ]; then
   #export RS_SERIAL_NO_L515_HEAD="";
 
   export NETWORK_DEFAULT_WIFI_INTERFACE="wlan1";
-  export NETWORK_DEFAULT_ROS_INTERFACE="localhost";
+  export NETWORK_DEFAULT_ROS_INTERFACE="fetch1075";
   export NETWORK_DEFAULT_PROFILE_ID="sanshiro-73B2";
 fi

--- a/jsk_fetch_robot/jsk_fetch_startup/config/config.bash
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/config.bash
@@ -20,6 +20,7 @@ if [ $(hostname) = 'fetch15' ]; then
   export RS_SERIAL_NO_L515_HEAD="";
 
   export NETWORK_DEFAULT_WIFI_INTERFACE="wlan0";
+  export NETWORK_DEFAULT_ROS_INTERFACE="localhost";
   export NETWORK_DEFAULT_PROFILE_ID="sanshiro-73B2";
 elif [ $(hostname) = 'fetch1075' ]; then
   export DEFAULT_SPEAKER=2;
@@ -40,5 +41,6 @@ elif [ $(hostname) = 'fetch1075' ]; then
   #export RS_SERIAL_NO_L515_HEAD="";
 
   export NETWORK_DEFAULT_WIFI_INTERFACE="wlan1";
+  export NETWORK_DEFAULT_ROS_INTERFACE="localhost";
   export NETWORK_DEFAULT_PROFILE_ID="sanshiro-73B2";
 fi

--- a/jsk_fetch_robot/jsk_fetch_startup/config/config_outside.bash
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/config_outside.bash
@@ -7,6 +7,6 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && 
 if [ $(hostname) = 'fetch15' ]; then
   export NETWORK_DEFAULT_PROFILE_ID="sanshiro-outside";
 elif [ $(hostname) = 'fetch1075' ]; then
-  export NETWORK_DEFAULT_ROS_INTERFACE="wlan0";
+  export NETWORK_DEFAULT_ROS_INTERFACE="fetch1075.local";
   export NETWORK_DEFAULT_PROFILE_ID="sanshiro-outside";
 fi

--- a/jsk_fetch_robot/jsk_fetch_startup/config/config_outside.bash
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/config_outside.bash
@@ -7,5 +7,6 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && 
 if [ $(hostname) = 'fetch15' ]; then
   export NETWORK_DEFAULT_PROFILE_ID="sanshiro-outside";
 elif [ $(hostname) = 'fetch1075' ]; then
+  export NETWORK_DEFAULT_ROS_INTERFACE="wlan0";
   export NETWORK_DEFAULT_PROFILE_ID="sanshiro-outside";
 fi

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-app-scheduler.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-app-scheduler.conf
@@ -1,5 +1,5 @@
 [program:jsk-app-scheduler]
-command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && if [ -e /var/lib/robot/config.bash ];then . /var/lib/robot/config.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && export ROS_HOSTNAME=$(hostname) && rosrun jsk_fetch_startup wait_app_manager.bash && roslaunch app_scheduler app_scheduler.launch yaml_path:=/var/lib/robot/app_schedule.yaml --wait --screen"
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && if [ -e /var/lib/robot/config.bash ];then . /var/lib/robot/config.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && rossetclient $NETWORK_DEFAULT_ROS_INTERFACE && rosrun jsk_fetch_startup wait_app_manager.bash && roslaunch app_scheduler app_scheduler.launch yaml_path:=/var/lib/robot/app_schedule.yaml --wait --screen"
 stopsignal=TERM
 directory=/home/fetch/ros/melodic
 ; autostart=true

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-dialog.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-dialog.conf
@@ -1,5 +1,5 @@
 [program:jsk-dialog]
-command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && if [ -e /var/lib/robot/config.bash ];then . /var/lib/robot/config.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && export ROS_HOSTNAME=$(hostname) && rosrun jsk_fetch_startup wait_app_manager.bash && roslaunch jsk_fetch_startup fetch_dialogflow_task_executive.launch run_app_manager:=false webhook_server:=true hostname:=$(hostname) --wait --screen "
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && if [ -e /var/lib/robot/config.bash ];then . /var/lib/robot/config.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && rossetclient $NETWORK_DEFAULT_ROS_INTERFACE && rosrun jsk_fetch_startup wait_app_manager.bash && roslaunch jsk_fetch_startup fetch_dialogflow_task_executive.launch run_app_manager:=false webhook_server:=true hostname:=$(hostname) --wait --screen "
 stopsignal=TERM
 directory=/home/fetch/ros/melodic
 ; autostart=true

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-fetch-startup-outside.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-fetch-startup-outside.conf
@@ -1,5 +1,5 @@
 [program:jsk-fetch-startup-outside]
-command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && if [ -e /var/lib/robot/config_outside.bash ];then . /var/lib/robot/config_outside.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && export ROS_HOSTNAME=$(hostname) && rosrun jsk_fetch_startup setup_audio.bash && roslaunch jsk_fetch_startup fetch_bringup.launch hostname:=$(hostname) boot_sound:=true default_speaker:=$DEFAULT_SPEAKER default_english_speaker:=$DEFAULT_ENGLISH_SPEAKER default_warning_speaker:=$DEFAULT_WARNING_SPEAKER network_interface:=$NETWORK_DEFAULT_WIFI_INTERFACE --wait"
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && if [ -e /var/lib/robot/config_outside.bash ];then . /var/lib/robot/config_outside.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && rossetclient $NETWORK_DEFAULT_ROS_INTERFACE && rosrun jsk_fetch_startup setup_audio.bash && roslaunch jsk_fetch_startup fetch_bringup.launch hostname:=$(hostname) boot_sound:=true default_speaker:=$DEFAULT_SPEAKER default_english_speaker:=$DEFAULT_ENGLISH_SPEAKER default_warning_speaker:=$DEFAULT_WARNING_SPEAKER network_interface:=$NETWORK_DEFAULT_WIFI_INTERFACE --wait"
 stopsignal=TERM
 directory=/home/fetch/ros/melodic
 autostart=false

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-fetch-startup.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-fetch-startup.conf
@@ -1,5 +1,5 @@
 [program:jsk-fetch-startup]
-command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && if [ -e /var/lib/robot/config.bash ];then . /var/lib/robot/config.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && export ROS_HOSTNAME=$(hostname) && rosrun jsk_fetch_startup setup_audio.bash && roslaunch jsk_fetch_startup fetch_bringup.launch hostname:=$(hostname) --wait"
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && if [ -e /var/lib/robot/config.bash ];then . /var/lib/robot/config.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && rossetclient $NETWORK_DEFAULT_ROS_INTERFACE && rosrun jsk_fetch_startup setup_audio.bash && roslaunch jsk_fetch_startup fetch_bringup.launch hostname:=$(hostname) --wait"
 stopsignal=TERM
 directory=/home/fetch/ros/melodic
 autostart=true

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-gdrive.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-gdrive.conf
@@ -1,5 +1,5 @@
 [program:jsk-gdrive]
-command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && if [ -e /var/lib/robot/config.bash ];then . /var/lib/robot/config.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && export ROS_HOSTNAME=$(hostname) && roslaunch gdrive_ros gdrive_server.launch --wait --screen respawn:=true"
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && if [ -e /var/lib/robot/config.bash ];then . /var/lib/robot/config.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && rossetclient $NETWORK_DEFAULT_ROS_INTERFACE && roslaunch gdrive_ros gdrive_server.launch --wait --screen respawn:=true"
 stopsignal=TERM
 directory=/home/fetch/ros/melodic
 ; autostart=true

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-network-monitor-outside.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-network-monitor-outside.conf
@@ -1,5 +1,5 @@
 [program:jsk-network-monitor-outside]
-command=/bin/bash -c ". /home/fetch/ros/melodic/devel/setup.bash && if [ -e /var/lib/robot/config_outside.bash ];then . /var/lib/robot/config_outside.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && export ROS_HOSTNAME=$(hostname) && rosrun jsk_fetch_startup network_monitor.py --interface $NETWORK_DEFAULT_WIFI_INTERFACE --profile $NETWORK_DEFAULT_PROFILE_ID"
+command=/bin/bash -c ". /home/fetch/ros/melodic/devel/setup.bash && if [ -e /var/lib/robot/config_outside.bash ];then . /var/lib/robot/config_outside.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && rossetclient $NETWORK_DEFAULT_ROS_INTERFACE && rosrun jsk_fetch_startup network_monitor.py --interface $NETWORK_DEFAULT_WIFI_INTERFACE --profile $NETWORK_DEFAULT_PROFILE_ID"
 stopsignal=TERM
 autostart=false
 autorestart=false

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-network-monitor.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-network-monitor.conf
@@ -1,5 +1,5 @@
 [program:jsk-network-monitor]
-command=/bin/bash -c ". /home/fetch/ros/melodic/devel/setup.bash && if [ -e /var/lib/robot/config.bash ];then . /var/lib/robot/config.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && export ROS_HOSTNAME=$(hostname) && rosrun jsk_fetch_startup network_monitor.py --interface $NETWORK_DEFAULT_WIFI_INTERFACE --profile $NETWORK_DEFAULT_PROFILE_ID"
+command=/bin/bash -c ". /home/fetch/ros/melodic/devel/setup.bash && if [ -e /var/lib/robot/config.bash ];then . /var/lib/robot/config.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && rossetclient $NETWORK_DEFAULT_ROS_INTERFACE && rosrun jsk_fetch_startup network_monitor.py --interface $NETWORK_DEFAULT_WIFI_INTERFACE --profile $NETWORK_DEFAULT_PROFILE_ID"
 stopsignal=TERM
 autostart=true
 autorestart=false

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-rfcomm-bind.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-rfcomm-bind.conf
@@ -1,5 +1,5 @@
 [program:jsk-rfcomm-bind]
-command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && if [ -e /var/lib/robot/config.bash ];then . /var/lib/robot/config.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && export ROS_HOSTNAME=$(hostname) && roslaunch jsk_robot_startup rfcomm_bind.launch --wait"
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && if [ -e /var/lib/robot/config.bash ];then . /var/lib/robot/config.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && rossetclient $NETWORK_DEFAULT_ROS_INTERFACE && roslaunch jsk_robot_startup rfcomm_bind.launch --wait"
 
 stopsignal=TERM
 directory=/home/fetch/ros/melodic

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-shutdown.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-shutdown.conf
@@ -1,5 +1,5 @@
 [program:jsk-shutdown]
-command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && if [ -e /var/lib/robot/config.bash ];then . /var/lib/robot/config.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && export ROS_HOSTNAME=$(hostname) && rosrun jsk_robot_startup shutdown.py --wait"
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && if [ -e /var/lib/robot/config.bash ];then . /var/lib/robot/config.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && rossetclient $NETWORK_DEFAULT_ROS_INTERFACE && rosrun jsk_robot_startup shutdown.py --wait"
 
 stopsignal=TERM
 directory=/home/fetch/ros/melodic

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/robot-outside.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/robot-outside.conf
@@ -1,5 +1,5 @@
 [program:robot-outside]
-command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && if [ -e /var/lib/robot/config_outside.bash ];then . /var/lib/robot/config_outside.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && export ROS_HOSTNAME=$(hostname) && rosrun jsk_fetch_startup link_calibration_files.bash && roslaunch jsk_fetch_startup fetch.launch launch_teleop:=false --wait --screen"
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && if [ -e /var/lib/robot/config_outside.bash ];then . /var/lib/robot/config_outside.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && rossetclient $NETWORK_DEFAULT_ROS_INTERFACE && rosrun jsk_fetch_startup link_calibration_files.bash && roslaunch jsk_fetch_startup fetch.launch launch_teleop:=false --wait --screen"
 stopsignal=TERM
 directory=/home/fetch/ros/melodic
 autostart=false

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/robot.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/robot.conf
@@ -1,5 +1,5 @@
 [program:robot]
-command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && if [ -e /var/lib/robot/config.bash ];then . /var/lib/robot/config.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && export ROS_HOSTNAME=$(hostname) && rosrun jsk_fetch_startup link_calibration_files.bash && roslaunch jsk_fetch_startup fetch.launch launch_teleop:=false --wait --screen"
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && if [ -e /var/lib/robot/config.bash ];then . /var/lib/robot/config.bash ;fi && export ROS_MASTER_URI=http://localhost:11311 && rossetclient $NETWORK_DEFAULT_ROS_INTERFACE && rosrun jsk_fetch_startup link_calibration_files.bash && roslaunch jsk_fetch_startup fetch.launch launch_teleop:=false --wait --screen"
 stopsignal=TERM
 directory=/home/fetch/ros/melodic
 autostart=true


### PR DESCRIPTION
Add `NETWORK_DEFAULT_ROS_INTERFACE` to config.bash and use it in supervisor conf as

```bash
rossetclient $NETWORK_DEFAULT_ROS_INTERFACE
```

to set `ROS_IP` *or* `ROS_HOSTNAME`.

By default, NETWORK_DEFAULT_ROS_INTERFACE is set to hostname of the robots.
When executing `rossetclient fetch1075`, `ROS_IP` is not set and `ROS_HOSTNAME` is set to `fetch1075`.

Please see config.bash for more detailed examples and see https://github.com/jsk-ros-pkg/jsk_common/pull/1746 for details about `rossetclient`.