### PR TITLE
[jsk_fetch_startup] Add launch to use m5stack sensors via rosserial + bluetooth

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
@@ -7,15 +7,6 @@
     <param name="score_thresh" type="double" value="0.60" /> <!-- default: 0.6 -->
   </node>
 
-  <!-- Use m5stack_ros -->
-  <!-- See https://github.com/jsk-ros-pkg/jsk_3rdparty/pull/289 -->
-  <node name="rosserial_m5stack" pkg="rosserial_python" type="serial_node.py">
-    <rosparam>
-      port: /dev/rfcomm0 <!-- See /var/lib/robot/rfcomm_devices.yaml -->
-      baud: 115200
-    </rosparam>
-  </node>
-
   <!-- Trash can occupancy detector -->
   <include file="$(find jsk_fetch_startup)/launch/trashbin_occupancy_detector.launch" />
 

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -360,4 +360,9 @@
     </rosparam>
   </node>
 
+  <!-- Two robots cannot use one rosserial device at the same time -->
+  <group if="$(eval hostname == 'fetch1075')">
+    <include file="$(find jsk_fetch_startup)/launch/fetch_rosserial.launch" />
+  </group>
+
 </launch>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_rosserial.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_rosserial.launch
@@ -1,0 +1,79 @@
+<launch>
+  <!-- The rfcomm device names (e.g. /dev/rfcomm0) corresponds to
+       the order of /var/lib/robot/rfcomm_devices.yaml -->
+  <!-- To bind rfcomm devices, https://github.com/jsk-ros-pkg/jsk_robot/pull/1401 is used -->
+
+  <!-- The firmwares are https://github.com/jsk-ros-pkg/jsk_3rdparty/pull/289 -->
+  <!-- Set logger leve to error to supress WARN when the device is not connected -->
+
+  <arg name="sgp30_ns" value="sgp30" />
+  <arg name="pdm_spm1423_ns" value="pdm_spm1423" />
+  <arg name="mlx90640_ns" value="mlx90640" />
+  <arg name="unitv_ns" value="unitv" />
+
+  <!-- rosseiral via Bluetooth -->
+  <!-- sgp30 gas sensor -->
+  <group ns="$(arg sgp30_ns)">
+    <node pkg="rosserial_python" type="serial_node.py" name="serial_node"
+          respawn="true" respawn_delay="10">
+      <rosparam subst_value="true">
+        port: /dev/rfcomm0
+        baud: 115200
+      </rosparam>
+    </node>
+    <node pkg="rosservice" type="rosservice" name="set_logger_level"
+          args="call --wait /$(arg sgp30_ns)/serial_node/set_logger_level 'rosout' 'error'" />
+  </group>
+  <!-- pdm_spm1423 microphone -->
+  <group ns="$(arg pdm_spm1423_ns)">
+    <node pkg="rosserial_python" type="serial_node.py" name="serial_node"
+          respawn="true" respawn_delay="10">
+      <rosparam subst_value="true">
+        port: /dev/rfcomm1
+        baud: 115200
+      </rosparam>
+    </node>
+    <node pkg="rosservice" type="rosservice" name="set_logger_level"
+          args="call --wait /$(arg pdm_spm1423_ns)/serial_node/set_logger_level 'rosout' 'error'" />
+  </group>
+  <!-- mlx90640 thermography -->
+  <group ns="$(arg mlx90640_ns)">
+    <node pkg="rosserial_python" type="serial_node.py" name="serial_node"
+          respawn="true" respawn_delay="10">
+      <rosparam subst_value="true">
+        port: /dev/rfcomm2
+        baud: 115200
+      </rosparam>
+    </node>
+    <node pkg="rosservice" type="rosservice" name="set_logger_level"
+          args="call --wait /$(arg mlx90640_ns)/serial_node/set_logger_level 'rosout' 'error'" />
+  </group>
+  <!-- unitv AI camera -->
+  <group ns="$(arg unitv_ns)">
+    <node pkg="rosserial_python" type="serial_node.py" name="serial_node"
+          respawn="true" respawn_delay="10">
+      <rosparam subst_value="true">
+        port: /dev/rfcomm3
+        baud: 115200
+      </rosparam>
+    </node>
+    <node pkg="rosservice" type="rosservice" name="set_logger_level"
+          args="call --wait /$(arg unitv_ns)/serial_node/set_logger_level 'rosout' 'error'" />
+    <!-- decompress unitv image -->
+    <node pkg="image_transport" type="republish" name="republish" args="compressed raw">
+      <remap from="in" to="unitv_image" />
+      <remap from="out" to="unitv_image" />
+    </node>
+    <!-- draw recognized result on unitv image -->
+    <node name="draw_rects" pkg="jsk_perception" type="draw_rects">
+      <remap from="~input" to="unitv_image" />
+      <remap from="~input/rects" to="unitv_image/rects" />
+      <remap from="~input/class" to="unitv_image/class" />
+      <rosparam>
+        use_classification_result: true
+        label_size: 0.3
+        resolution_factor: 2.0
+      </rosparam>
+    </node>
+  </group>
+</launch>

--- a/jsk_robot_common/jsk_robot_startup/scripts/rfcomm_bind.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/rfcomm_bind.py
@@ -37,6 +37,11 @@ class RfcommBind(object):
         else:
             rospy.logerr('Cannot find {}'.format(yaml_path))
 
+    def release_devices(self):
+        subprocess.call(
+            ['sudo', 'rfcomm', 'release', 'all'],
+            stdout=PIPE, stderr=PIPE)
+
     def bind_devices(self):
         dev_num = 0
         for dev in self.rfcomm_devices:
@@ -57,4 +62,5 @@ class RfcommBind(object):
 if __name__ == "__main__":
     rospy.init_node('rfcomm_bind')
     app = RfcommBind()
+    app.release_devices()
     app.bind_devices()


### PR DESCRIPTION
With this PR, fetch1075 can always communicate with m5stacks, which is usually powered by a refrigerator.
- When m5stack is charged, fetch1075 can get the m5stack battery rostopics. (The sensors are not available to save m5stack battery)
- When m5stack is not charged, fetch1075 can get each sensor rostopics in addition to the battery rostopics.

Only fetch1075 uses m5stacks because two robots (fetch15 and fetch1075) cannot use one rosserial device at the same time.

![m5stacks_charged](https://user-images.githubusercontent.com/19769486/176753587-28c492b0-a71e-41bc-ad16-9359e0b1db99.jpg)

Related to 
https://github.com/jsk-ros-pkg/jsk_robot/pull/1519
[jsk-ros-pkg/jsk_robot@`e1e8836` (#1401)](https://github.com/jsk-ros-pkg/jsk_robot/pull/1401/commits/e1e8836f0658203030110cb6ec7175a56d495a9d)
