### PR TITLE
Pr/fetchdev/make insta360 low resolution mode

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_insta360_melodic.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_insta360_melodic.launch
@@ -7,11 +7,13 @@
     <!-- To check the valid formats, -->
     <!-- $ sudo apt-get install v4l-utils -->
     <!-- $ v4l2-ctl -d /dev/insta360 -\-list-formats-ext -->
-    <arg name="height" value="736" />
-    <arg name="width" value="1472" />
+    <arg name="height" value="1088" />
+    <arg name="width" value="2176" />
     <arg name="throttle" value="true" />
+    <arg name="throttled_rate" value="1.0" />
     <!-- for melodic -->
     <arg name="use_usb_cam" value="false" />
+    <arg name="panorama_resolution_mode" value="low" />
   </include>
 
   <group ns="dual_fisheye_to_panorama">
@@ -23,8 +25,8 @@
       <remap from="~image" to="quater/output" />
       <remap from="~camera_info" to="quater/camera_info" />
       <rosparam>
-        scale_width: 0.25
-        scale_height: 0.25
+        scale_width: 0.5
+        scale_height: 0.5
       </rosparam>
     </node>
   </group>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_insta360_melodic.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_insta360_melodic.launch
@@ -10,7 +10,7 @@
     <arg name="height" value="1088" />
     <arg name="width" value="2176" />
     <arg name="throttle" value="true" />
-    <arg name="throttled_rate" value="1.0" />
+    <arg name="throttled_rate" value="10.0" />
     <!-- for melodic -->
     <arg name="use_usb_cam" value="false" />
     <arg name="panorama_resolution_mode" value="low" />


### PR DESCRIPTION
変更点は以下

a. insta360 の もともとの解像度を 2Kx1K くらいに変更
b. dual_fisheye_to_panorama を low resolution モードに変更 ( `/dual_fisheye_to_panorama/output` の解像度が2Kx1Kになる)
c. insta360 の throttle のレートを 10Hz に変更

以下はCPU使用率の確認

## 変更前

![high_01Hz_htop_crop](https://user-images.githubusercontent.com/9410362/177089017-2a63b5c7-ab9f-41bd-b548-95878460df44.png)

## a+b

![low_01Hz_htop_crop](https://user-images.githubusercontent.com/9410362/177090216-edb3655d-ebac-4a0f-95a5-18afa6a5468f.png)

insta360の解像度を上げたのでcamera_nodeのCPU使用率は上がっている。low resolution モードへの変更は throttle レートが低いのでCPU使用率の変更的にはあまり影響がない

## a+b+c

![low_10Hz_htop_crop](https://user-images.githubusercontent.com/9410362/177090445-6ebc4d6b-56c0-494a-bfed-25921b531011.png)

insta360のレートを上げたので, dual_fisheye_to_panorama のCPU使用率は上がるが、他の処理に影響を及ぼすほどはリソースを奪ってはい無さそう。