### PR TITLE
[jsk_fetch_startup] Ignore rosserial audible warning because it automatically reconnects

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/config/warning_blacklist.yaml
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/warning_blacklist.yaml
@@ -3,6 +3,7 @@ blacklist:
   - name: "/Other/amcl: Standard deviation"
   - name: "/Other/jsk_joy_node: Joystick Driver Status"
   - name: "/Other/l515_head l515_head_realsense2_camera_.*: Frequency Status"
+  - name: "/Other/rosserial_python"
   - name: "/Peripherals/PS3 Controller"
   - name: "/Sensors/IMU/IMU.*"
   - name: "/SoundPlay/sound_play.*"


### PR DESCRIPTION
`rosrun rosserial_python seiral_node.py` via bluetooth sometimes loses connection.
At that time, `serial_node.py` generates a diagnostics error as follows.
![ignore_rosserial_error](https://user-images.githubusercontent.com/19769486/177213421-30dfe29b-c97c-4e5e-98ea-4f263befbb00.png)

However, `serial_node.py` can automatically reconnect after losing connection.
So I think `audible_warning` should ignore this diagnostics error.