### PR TITLE
Speed up bag_to_video.py by setting fps to 5 and disable compression.

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -14,7 +14,7 @@ plugins:
     launch_args:
       rosbag_path: /tmp
       rosbag_title: go_to_kitchen_rosbag.bag
-      compress: true
+      compress: false
       rosbag_topic_names:
         - /rosout
         - /tf

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -63,7 +63,7 @@ plugins:
       rosbag_path: /tmp
       rosbag_title: go_to_kitchen_rosbag.bag
       image_topic_name: /edgetpu_object_detector/output/image/compressed
-      image_fps: 30
+      image_fps: 5
       audio_topic_name: /audio
       audio_sample_rate: 16000
       audio_channels: 1
@@ -82,7 +82,7 @@ plugins:
       rosbag_path: /tmp
       rosbag_title: go_to_kitchen_rosbag.bag
       image_topic_name: /rviz/image/compressed
-      image_fps: 30
+      image_fps: 5
       video_path: /tmp/go_to_kitchen_rviz.mp4
   - name: respeaker_audio_converter_plugin
     type: app_recorder/rosbag_audio_converter_plugin


### PR DESCRIPTION
# What is this?

This PR is related to https://github.com/knorth55/jsk_robot/issues/283 .
The kitchen demo creates a video from rosbag, but it's slow and it takes time to get an email.

```
fetch@fetch1075:/tmp$ ls -althr | grep rosbag
-rw-r--r--  1 fetch        fetch        622M  7月  6 09:32 go_to_kitchen_rosbag.bag
fetch@fetch1075:/tmp$ rosbag decompress go_to_kitchen_rosbag.bag
go_to_kitchen_rosbag.bag                                                                                                                                               100%            704.7 MB 01:17
fetch@fetch1075:/tmp$ ls -althr | grep .bag
-rw-r--r--  1 fetch        fetch        622M  7月  6 09:32 go_to_kitchen_rosbag.orig.bag
-rw-rw-r--  1 fetch        fetch        707M  7月  6 18:36 go_to_kitchen_rosbag.bag

fetch@fetch1075:/tmp$ time rosrun jsk_rosbag_tools bag_to_video.py /tmp/go_to_kitchen_rosbag.orig.bag --samplerate 16000 --channels 1 --audio-topic /audio --image-topic /head_camera/rgb/throttled/image_r
ect_color/compressed -o /tmp/go_to_kitchen_rosbag.orig.mp4
[bag_to_video] Extracting audio from rosbag file.
[bag_to_video] Creating video of /head_camera/rgb/throttled/image_rect_color/compressed from rosbag file /tmp/go_to_kitchen_rosbag.orig.bag.
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 496/496 [00:56<00:00,  8.79it/s]
[bag_to_video] Combine video and audio
Moviepy - Building video /tmp/go_to_kitchen_rosbag.orig.mp4.
MoviePy - Writing audio in go_to_kitchen_rosbag.origTEMP_MPY_wvf_snd.mp3
MoviePy - Done.
Moviepy - Writing video /tmp/go_to_kitchen_rosbag.orig.mp4

Moviepy - Done !
Moviepy - video ready /tmp/go_to_kitchen_rosbag.orig.mp4
[bag_to_video] Created video is saved to /tmp/go_to_kitchen_rosbag.orig.mp4

real    2m29.816s
user    4m9.540s
sys     0m9.630s


fetch@fetch1075:/tmp$ time rosrun jsk_rosbag_tools bag_to_video.py /tmp/go_to_kitchen_rosbag.bag --samplerate 16000 --channels 1 --audio-topic /audio --image-topic /head_camera/rgb/throttled/image_rect_c
olor/compressed -o /tmp/go_to_kitchen_rosbag.mp4
[bag_to_video] Extracting audio from rosbag file.
[bag_to_video] Creating video of /head_camera/rgb/throttled/image_rect_color/compressed from rosbag file /tmp/go_to_kitchen_rosbag.bag.
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 496/496 [00:18<00:00, 27.42it/s]
[bag_to_video] Combine video and audio
Moviepy - Building video /tmp/go_to_kitchen_rosbag.mp4.
MoviePy - Writing audio in go_to_kitchen_rosbagTEMP_MPY_wvf_snd.mp3
MoviePy - Done.
Moviepy - Writing video /tmp/go_to_kitchen_rosbag.mp4

Moviepy - Done !
Moviepy - video ready /tmp/go_to_kitchen_rosbag.mp4
[bag_to_video] Created video is saved to /tmp/go_to_kitchen_rosbag.mp4

real    0m42.434s
user    2m21.369s
sys     0m9.625s

```

3 times faster.