### PR TITLE
[jsk_fetch_startup] Add option to change L515 resolution

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/config/config.bash
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/config.bash
@@ -41,6 +41,8 @@ elif [ $(hostname) = 'fetch1075' ]; then
   # Use L515 after finding a way to reduce L515 CPU usage like ConnectionBasedTransport
   export RS_SERIAL_NO_L515_HEAD="f0232270";
   #export RS_SERIAL_NO_L515_HEAD="";
+  # Currently, fetch1075 uses USB 2 for L515, so high resolution mode is not available.
+  export L515_HIGH_RESOLUTION=false;
 
   export NETWORK_DEFAULT_WIFI_INTERFACE="wlan1";
   export NETWORK_DEFAULT_ROS_INTERFACE="fetch1075";

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch.launch
@@ -17,6 +17,7 @@
   <arg name="RS_SERIAL_NO_D435_FRONTRIGHT" default="$(optenv RS_SERIAL_NO_D435_FRONTRIGHT)" />
   <arg name="RS_SERIAL_NO_D435_FRONTLEFT" default="$(optenv RS_SERIAL_NO_D435_FRONTLEFT)" />
   <arg name="RS_SERIAL_NO_L515_HEAD" default="$(optenv RS_SERIAL_NO_L515_HEAD)" />
+  <arg name="l515_high_resolution" default="$(optenv L515_HIGH_RESOLUTION true)" />
 
   <!-- GDB Debug Option -->
   <arg name="debug" default="false"/>
@@ -40,6 +41,7 @@
       <arg name="RS_SERIAL_NO_D435_FRONTRIGHT" value="$(arg RS_SERIAL_NO_D435_FRONTRIGHT)" />
       <arg name="RS_SERIAL_NO_D435_FRONTLEFT" value="$(arg RS_SERIAL_NO_D435_FRONTLEFT)" />
       <arg name="RS_SERIAL_NO_L515_HEAD" value="$(arg RS_SERIAL_NO_L515_HEAD)" />
+      <arg name="l515_high_resolution" value="$(arg l515_high_resolution)" />
   </include>
 
   <!-- Odometry -->

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_realsense_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_realsense_bringup.launch
@@ -7,6 +7,19 @@
   <arg name="RS_SERIAL_NO_D435_FRONTLEFT" default="" />
   <arg name="RS_SERIAL_NO_L515_HEAD" default="" />
 
+  <arg name="l515_high_resolution" default="true" />
+  <!-- Available profiles can be shown by $ rs-enumerate-devices -->
+  <!-- L515 high resolution -->
+  <arg name="l515_color_width" default="1920" if="$(arg l515_high_resolution)" />
+  <arg name="l515_color_height" default="1080" if="$(arg l515_high_resolution)" />
+  <arg name="l515_depth_width" default="640" if="$(arg l515_high_resolution)" />
+  <arg name="l515_depth_height" default="480" if="$(arg l515_high_resolution)" />
+  <!-- L515 low resolution -->
+  <arg name="l515_color_width" default="640" unless="$(arg l515_high_resolution)" />
+  <arg name="l515_color_height" default="480" unless="$(arg l515_high_resolution)" />
+  <arg name="l515_depth_width" default="320" unless="$(arg l515_high_resolution)" />
+  <arg name="l515_depth_height" default="240" unless="$(arg l515_high_resolution)" />
+
   <!-- t265 -->
   <group ns="t265" if="$(eval arg('RS_SERIAL_NO_T265') != '')">
     <rosparam>
@@ -91,10 +104,10 @@
       <arg name="initial_reset"         value="true"/>
       <arg name="align_depth"           value="true"/>
       <arg name="filters"               value="pointcloud"/>
-      <arg name="color_width"           value="1920"/>
-      <arg name="color_height"          value="1080"/>
-      <arg name="depth_width"           value="640"/>
-      <arg name="depth_height"          value="480"/>
+      <arg name="color_width"           value="$(arg l515_color_width)"/>
+      <arg name="color_height"          value="$(arg l515_color_height)"/>
+      <arg name="depth_width"           value="$(arg l515_depth_width)"/>
+      <arg name="depth_height"          value="$(arg l515_depth_height)"/>
       <arg name="clip_distance"         value="-2"/>
       <arg name="enable_pointcloud"     value="false"/>
       <arg name="enable_infra"          value="true"/>


### PR DESCRIPTION
I add option to select L515 resolution.
I set L515 low resolution mode for fetch1075, because USB 2 is used for fetch1075's L515 camera.

@sktometometo 
Could you merge this PR if there is no problem?