### PR TITLE
[jsk_fetch_startup] Update PR list on which fetch's rosserial depends

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -77,7 +77,10 @@
     local-name: ros-drivers/audio_common
     uri: https://github.com/ros-drivers/audio_common.git
     version: master
-# Remove after https://github.com/ros-drivers/rosserial/pull/570 is merged and released
+# Remove after the following PRs are merged and released
+# https://github.com/ros-drivers/rosserial/pull/570
+# https://github.com/ros-drivers/rosserial/pull/594
+# https://github.com/ros-drivers/rosserial/pull/596
 - git:
     local-name: ros-drivers/rosserial
     uri: https://github.com/708yamaguchi/rosserial.git


### PR DESCRIPTION
This rosinstall solves https://github.com/jsk-ros-pkg/jsk_robot/issues/1531#issuecomment-1188066561

cc @sktometometo 