### PR TITLE
[jsk_fetch_startup] Reset rosserial logger level for debuging

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_rosserial.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_rosserial.launch
@@ -4,7 +4,11 @@
   <!-- To bind rfcomm devices, https://github.com/jsk-ros-pkg/jsk_robot/pull/1401 is used -->
 
   <!-- The firmwares are https://github.com/jsk-ros-pkg/jsk_3rdparty/pull/289 -->
-  <!-- Set logger leve to error to supress WARN when the device is not connected -->
+  <!-- Set logger level to error to supress WARN when the device is not connected -->
+  <!-- 2022/07/19, change logger level to info for debugging -->
+  <!-- Reset the level to error if there is no problem with rosserial -->
+  <!-- For detail, see https://github.com/jsk-ros-pkg/jsk_robot/issues/1531#issuecomment-1188066561 -->
+  <arg name="logger_level" default="info" />
 
   <arg name="sgp30_ns" value="sgp30" />
   <arg name="pdm_spm1423_ns" value="pdm_spm1423" />
@@ -23,7 +27,7 @@
       </rosparam>
     </node>
     <node pkg="rosservice" type="rosservice" name="set_logger_level"
-          args="call --wait /$(arg sgp30_ns)/serial_node/set_logger_level 'rosout' 'error'" />
+          args="call --wait /$(arg sgp30_ns)/serial_node/set_logger_level 'rosout' '$(arg logger_level)'" />
   </group>
   <!-- pdm_spm1423 microphone -->
   <group ns="$(arg pdm_spm1423_ns)">
@@ -35,7 +39,7 @@
       </rosparam>
     </node>
     <node pkg="rosservice" type="rosservice" name="set_logger_level"
-          args="call --wait /$(arg pdm_spm1423_ns)/serial_node/set_logger_level 'rosout' 'error'" />
+          args="call --wait /$(arg pdm_spm1423_ns)/serial_node/set_logger_level 'rosout' '$(arg logger_level)'" />
   </group>
   <!-- mlx90640 thermography -->
   <group ns="$(arg mlx90640_ns)">
@@ -47,7 +51,7 @@
       </rosparam>
     </node>
     <node pkg="rosservice" type="rosservice" name="set_logger_level"
-          args="call --wait /$(arg mlx90640_ns)/serial_node/set_logger_level 'rosout' 'error'" />
+          args="call --wait /$(arg mlx90640_ns)/serial_node/set_logger_level 'rosout' '$(arg logger_level)'" />
   </group>
   <!-- unitv AI camera -->
   <group ns="$(arg unitv_ns)">
@@ -59,7 +63,7 @@
       </rosparam>
     </node>
     <node pkg="rosservice" type="rosservice" name="set_logger_level"
-          args="call --wait /$(arg unitv_ns)/serial_node/set_logger_level 'rosout' 'error'" />
+          args="call --wait /$(arg unitv_ns)/serial_node/set_logger_level 'rosout' '$(arg logger_level)'" />
     <!-- decompress unitv image -->
     <node pkg="image_transport" type="republish" name="republish" args="compressed raw">
       <remap from="in" to="unitv_image" />
@@ -87,6 +91,6 @@
       </rosparam>
     </node>
     <node pkg="rosservice" type="rosservice" name="set_logger_level"
-          args="call --wait /$(arg enviii_ns)/serial_node/set_logger_level 'rosout' 'error'" />
+          args="call --wait /$(arg enviii_ns)/serial_node/set_logger_level 'rosout' '$(arg logger_level)'" />
   </group>
 </launch>


### PR DESCRIPTION
From https://github.com/jsk-ros-pkg/jsk_robot/issues/1531#issuecomment-1188066561

I reset logger level to `info` for debugging.
I will reset the level to `error` if there is no problem with rosserial