### PR TITLE
[jsk_fetch_startup] Use symbolic link for udev rules file, as well as supervisor configs

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/config/install_udev.sh
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/install_udev.sh
@@ -4,14 +4,6 @@ jsk_fetch_startup=$(builtin cd "`dirname "${BASH_SOURCE[0]}"`"/.. > /dev/null &&
 
 cd $jsk_fetch_startup/udev_rules
 for file in $(ls *.rules); do
-    if [ -e /etc/udev/rules.d/$file ]; then
-        file_bk=$file.$(date "+%Y%m%d_%H%M%S")
-        sudo cp /etc/udev/rules.d/$file /etc/udev/rules.d/$file_bk
-        echo "backup /etc/udev/rules.d/$file to /etc/udev/rules.d/$file_bk"
-    fi
-
-    sudo cp $file /etc/udev/rules.d/
-    sudo chown root:root /etc/udev/rules.d/$file
-    sudo chmod 644 /etc/udev/rules.d/$file
-    echo -e "copied jsk_fetch_startup/udev_rules/$file to /etc/udev/rules.d/$file\n"
+    sudo ln -sf $jsk_fetch_startup/udev_rules/$file /etc/udev/rules.d/$file
+    echo -e "Create symbolic link from jsk_fetch_startup/udev_rules/$file to /etc/udev/rules.d/$file\n"
 done


### PR DESCRIPTION
I use symbolic link for udev rules as well as supervisor configs.
c.f. https://github.com/knorth55/jsk_robot/commit/aa2a7d4bb1f3d5053294189190a4086bca9738e2

I think it is a bit confusing to use
- `ln -sf` for supervisor configs
- `cp` for udev rules

cc @knorth55 