### PR TITLE
[jsk_fetch_startup] Use L515 high resolution for fetch1075 because USB3 is used now

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/config/config.bash
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/config.bash
@@ -41,8 +41,6 @@ elif [ $(hostname) = 'fetch1075' ]; then
   # Use L515 after finding a way to reduce L515 CPU usage like ConnectionBasedTransport
   export RS_SERIAL_NO_L515_HEAD="f0232270";
   #export RS_SERIAL_NO_L515_HEAD="";
-  # Currently, fetch1075 uses USB 2 for L515, so high resolution mode is not available.
-  export L515_HIGH_RESOLUTION=false;
 
   export NETWORK_DEFAULT_WIFI_INTERFACE="wlan1";
   export NETWORK_DEFAULT_ROS_INTERFACE="fetch1075";


### PR DESCRIPTION
Since yesterday, fetch1075 uses L515 via USB3 and uses the high resolution mode.

cc @sktometometo 