### PR TITLE
[jsk_fetch_startup] Remove pointcloud from filters to disable publishing pointcloud

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_realsense_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_realsense_bringup.launch
@@ -69,7 +69,6 @@
       <arg name="tf_prefix"             value="d435_front_right"/>
       <arg name="initial_reset"         value="true"/>
       <arg name="align_depth"           value="true"/>
-      <arg name="filters"               value="pointcloud"/>
       <arg name="color_width"           value="640"/>
       <arg name="color_height"          value="480"/>
       <arg name="depth_width"           value="640"/>
@@ -86,7 +85,6 @@
       <arg name="tf_prefix"             value="d435_front_left"/>
       <arg name="initial_reset"         value="true"/>
       <arg name="align_depth"           value="true"/>
-      <arg name="filters"               value="pointcloud"/>
       <arg name="color_width"           value="640"/>
       <arg name="color_height"          value="480"/>
       <arg name="depth_width"           value="640"/>
@@ -103,7 +101,6 @@
       <arg name="tf_prefix"             value="l515_head"/>
       <arg name="initial_reset"         value="true"/>
       <arg name="align_depth"           value="true"/>
-      <arg name="filters"               value="pointcloud"/>
       <arg name="color_width"           value="$(arg l515_color_width)"/>
       <arg name="color_height"          value="$(arg l515_color_height)"/>
       <arg name="depth_width"           value="$(arg l515_depth_width)"/>


### PR DESCRIPTION
I want to have option to disable pointcloud to reduce CPU usage. (200% is used on average)
However, I cannot disable pointcloud even when I set `enable_pointcloud` to false.
This is because `pointcloud` is set to `filters` rosparam by default.
c.f.
https://github.com/IntelRealSense/realsense-ros/blob/579a465a7dece96c514d1258ef0960e6de461422/realsense2_camera/src/base_realsense_node.cpp#L738-L739

@sktometometo 
Can you explain why this filter is needed?
In addition, please add documentation or comment about why you need JSK version realsense node, why you use standalone and why you need to change many params?
c.f.
https://github.com/knorth55/jsk_robot/pull/82

