### PR TITLE
[jsk_fetch_startup] Create L515 points from throttled rgb and depth images

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/devices/realsense_nodelet.launch.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/devices/realsense_nodelet.launch.xml
@@ -3,6 +3,8 @@
     This launch file is copied from realsense2_camera in realsense_ros https://github.com/IntelRealSense/realsense-ros and then modified
     And it is originally distributed under Apache-2.0 License
   -->
+  <arg name="external_manager"    default="false"/>
+  <arg name="manager"             default="realsense2_camera_manager"/>
   <arg name="serial_no"           default=""/>
   <arg name="usb_port_id"         default=""/>
   <arg name="device_type"         default=""/>
@@ -10,6 +12,7 @@
   <arg name="json_file_path"      default=""/>
   <arg name="rosbag_filename"     default=""/>
   <arg name="respawn"             default="false"/>
+  <arg name="required"            default="false"/>
   <arg name="output"              default="screen"/>  <!-- [ screen | log ]-->
 
   <arg name="fisheye_width"       default="0"/>
@@ -101,11 +104,12 @@
   <arg name="initial_reset"            default="false"/>
   <arg name="unite_imu_method"         default="none"/> <!-- Options are: [none, copy, linear_interpolation] -->
 
+  <node unless="$(arg external_manager)" pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="$(arg output)" required="$(arg required)"/>
   <node
       pkg="nodelet"
       type="nodelet"
       name="$(arg tf_prefix)_realsense2_camera"
-      args="standalone realsense2_camera/RealSenseNodeFactory"
+      args="load realsense2_camera/RealSenseNodeFactory $(arg manager)"
       respawn="$(arg respawn)">
     <param name="serial_no"                type="str"  value="$(arg serial_no)"/>
     <param name="usb_port_id"              type="str"  value="$(arg usb_port_id)"/>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch.launch
@@ -42,6 +42,7 @@
       <arg name="RS_SERIAL_NO_D435_FRONTLEFT" value="$(arg RS_SERIAL_NO_D435_FRONTLEFT)" />
       <arg name="RS_SERIAL_NO_L515_HEAD" value="$(arg RS_SERIAL_NO_L515_HEAD)" />
       <arg name="l515_high_resolution" value="$(arg l515_high_resolution)" />
+      <arg name="enable_pointcloud" value="true" />
   </include>
 
   <!-- Odometry -->

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_realsense_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_realsense_bringup.launch
@@ -1,6 +1,7 @@
 <launch>
 
   <arg name="respawn" default="true" />
+  <arg name="manager" default="realsense2_camera_manager" />
 
   <arg name="RS_SERIAL_NO_T265" default="" />
   <arg name="RS_SERIAL_NO_D435_FRONTRIGHT" default="" />
@@ -19,6 +20,11 @@
   <arg name="l515_color_height" default="480" unless="$(arg l515_high_resolution)" />
   <arg name="l515_depth_width" default="320" unless="$(arg l515_high_resolution)" />
   <arg name="l515_depth_height" default="240" unless="$(arg l515_high_resolution)" />
+
+  <!-- Args for depth registration and pointcloud -->
+  <arg name="rgb"                             default="color" />
+  <arg name="depth_registered_pub"            default="depth_registered" />
+  <arg name="depth_registered"                default="aligned_depth_to_color" />
 
   <!-- t265 -->
   <group ns="t265" if="$(eval arg('RS_SERIAL_NO_T265') != '')">
@@ -94,6 +100,8 @@
       <arg name="respawn"              value="$(arg respawn)"/>
     </include>
   </group>
+
+  <!-- L515 -->
   <group ns="l515_head" if="$(eval arg('RS_SERIAL_NO_L515_HEAD') != '')">
     <include file="$(find jsk_fetch_startup)/launch/devices/realsense_nodelet.launch.xml">
       <arg name="device_type"           value="l515"/>
@@ -115,6 +123,26 @@
         /l515_head/l500_depth_sensor/global_time_enabled: true
         /l515_head/rgb_camera/global_time_enabled: true
     </rosparam>
+    <!-- Create pointcloud with throttled RGB and depth image to reduce CPU usage -->
+    <!--
+        This launch file is copied from realsense2_camera in realsense_ros https://github.com/IntelRealSense/realsense-ros and then modified
+        And it is originally distributed under Apache-2.0 License
+    -->
+    <!-- Create rectified image -->
+    <include file="$(find rgbd_launch)/launch/includes/rgb.launch.xml">
+      <arg name="manager"                       value="/l515_head/$(arg manager)" />
+      <arg name="respawn"                       value="$(arg respawn)" />
+      <arg name="rgb"                           value="$(arg rgb)" />
+      <arg name="debayer_processing"            value="false" />
+    </include>
+    <!-- Publish registered XYZRGB point cloud with hardware registered input (ROS Realsense depth alignment) -->
+    <node pkg="nodelet" type="nodelet" name="points_xyzrgb_hw_registered"
+          args="load depth_image_proc/point_cloud_xyzrgb /l515_head/$(arg manager)" respawn="$(arg respawn)">
+      <remap from="rgb/image_rect_color"        to="$(arg rgb)/image_rect_color"        />
+      <remap from="rgb/camera_info"             to="$(arg rgb)/camera_info"             />
+      <remap from="depth_registered/image_rect" to="$(arg depth_registered)/image_raw"  />
+      <remap from="depth_registered/points"     to="$(arg depth_registered_pub)/points" />
+    </node>
   </group>
 
 </launch>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_realsense_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_realsense_bringup.launch
@@ -22,6 +22,7 @@
   <arg name="l515_depth_height" default="240" unless="$(arg l515_high_resolution)" />
 
   <!-- Args for depth registration and pointcloud -->
+  <arg name="enable_pointcloud"               default="true" doc="If false, L515 pointcloud is not created and published" />
   <arg name="rgb"                             default="color" />
   <arg name="depth_registered_pub"            default="depth_registered" />
   <arg name="depth_registered"                default="aligned_depth_to_color" />
@@ -82,7 +83,7 @@
       <arg name="depth_width"           value="640"/>
       <arg name="depth_height"          value="480"/>
       <arg name="clip_distance"         value="-2"/>
-      <arg name="enable_pointcloud"     value="true"/>
+      <arg name="enable_pointcloud"     value="$(arg enable_pointcloud)"/>
       <arg name="respawn"              value="$(arg respawn)"/>
     </include>
   </group>
@@ -98,7 +99,7 @@
       <arg name="depth_width"           value="640"/>
       <arg name="depth_height"          value="480"/>
       <arg name="clip_distance"         value="-2"/>
-      <arg name="enable_pointcloud"     value="true"/>
+      <arg name="enable_pointcloud"     value="$(arg enable_pointcloud)"/>
       <arg name="respawn"              value="$(arg respawn)"/>
     </include>
   </group>
@@ -130,58 +131,60 @@
         This launch file is copied from realsense2_camera in realsense_ros https://github.com/IntelRealSense/realsense-ros and then modified
         And it is originally distributed under Apache-2.0 License
     -->
-    <!-- Create rectified image -->
-    <include file="$(find rgbd_launch)/launch/includes/rgb.launch.xml">
-      <arg name="manager"                       value="/l515_head/$(arg manager)" />
-      <arg name="respawn"                       value="$(arg respawn)" />
-      <arg name="rgb"                           value="$(arg rgb)" />
-      <arg name="debayer_processing"            value="false" />
-    </include>
-    <group if="$(arg throttle_l515_points)">
-      <group ns="$(arg rgb)">
-        <!-- Throttle RGB images -->
-        <node name="throttle_image"
-              pkg="nodelet" type="nodelet"
-              args="load jsk_topic_tools/LightweightThrottle /l515_head/$(arg manager)"
-              respawn="true">
-          <remap from="~input" to="image_rect_color" />
-          <remap from="~output" to="throttled/image_rect_color" />
-          <param name="update_rate" value="$(arg throttled_rate)" />
-        </node>
-        <!-- Throttle camera info -->
-        <node name="throttle_camera_info"
-              pkg="nodelet" type="nodelet"
-              args="load jsk_topic_tools/LightweightThrottle /l515_head/$(arg manager)"
-              respawn="true">
-          <remap from="~input" to="camera_info" />
-          <remap from="~output" to="throttled/camera_info" />
-          <param name="update_rate" value="$(arg throttled_rate)" />
-        </node>
+    <group if="$(arg enable_pointcloud)">
+      <!-- Create rectified image -->
+      <include file="$(find rgbd_launch)/launch/includes/rgb.launch.xml">
+        <arg name="manager"                       value="/l515_head/$(arg manager)" />
+        <arg name="respawn"                       value="$(arg respawn)" />
+        <arg name="rgb"                           value="$(arg rgb)" />
+        <arg name="debayer_processing"            value="false" />
+      </include>
+      <group if="$(arg throttle_l515_points)">
+        <group ns="$(arg rgb)">
+          <!-- Throttle RGB images -->
+          <node name="throttle_image"
+                pkg="nodelet" type="nodelet"
+                args="load jsk_topic_tools/LightweightThrottle /l515_head/$(arg manager)"
+                respawn="true">
+            <remap from="~input" to="image_rect_color" />
+            <remap from="~output" to="throttled/image_rect_color" />
+            <param name="update_rate" value="$(arg throttled_rate)" />
+          </node>
+          <!-- Throttle camera info -->
+          <node name="throttle_camera_info"
+                pkg="nodelet" type="nodelet"
+                args="load jsk_topic_tools/LightweightThrottle /l515_head/$(arg manager)"
+                respawn="true">
+            <remap from="~input" to="camera_info" />
+            <remap from="~output" to="throttled/camera_info" />
+            <param name="update_rate" value="$(arg throttled_rate)" />
+          </node>
+        </group>
+        <group ns="$(arg depth_registered)">
+          <!-- Throttle depth images -->
+          <node name="throttle_image"
+                pkg="nodelet" type="nodelet"
+                args="load jsk_topic_tools/LightweightThrottle /l515_head/$(arg manager)"
+                respawn="true">
+            <remap from="~input" to="image_raw" />
+            <remap from="~output" to="throttled/image_raw" />
+            <param name="update_rate" value="$(arg throttled_rate)" />
+          </node>
+        </group>
       </group>
-      <group ns="$(arg depth_registered)">
-        <!-- Throttle depth images -->
-        <node name="throttle_image"
-              pkg="nodelet" type="nodelet"
-              args="load jsk_topic_tools/LightweightThrottle /l515_head/$(arg manager)"
-              respawn="true">
-          <remap from="~input" to="image_raw" />
-          <remap from="~output" to="throttled/image_raw" />
-          <param name="update_rate" value="$(arg throttled_rate)" />
-        </node>
-      </group>
+      <!-- Publish registered XYZRGB point cloud with hardware registered input (ROS Realsense depth alignment) -->
+      <!-- The output topic name is always /l515_head/depth_registered/points regardless of throttle option -->
+      <node pkg="nodelet" type="nodelet" name="points_xyzrgb_hw_registered"
+            args="load depth_image_proc/point_cloud_xyzrgb /l515_head/$(arg manager)" respawn="$(arg respawn)">
+        <remap from="rgb/image_rect_color"        to="$(arg rgb)/throttled/image_rect_color"        if="$(arg throttle_l515_points)" />
+        <remap from="rgb/image_rect_color"        to="$(arg rgb)/image_rect_color"                  unless="$(arg throttle_l515_points)" />
+        <remap from="rgb/camera_info"             to="$(arg rgb)/throttled/camera_info"             if="$(arg throttle_l515_points)" />
+        <remap from="rgb/camera_info"             to="$(arg rgb)/camera_info"                       unless="$(arg throttle_l515_points)" />
+        <remap from="depth_registered/image_rect" to="$(arg depth_registered)/throttled/image_raw"  if="$(arg throttle_l515_points)" />
+        <remap from="depth_registered/image_rect" to="$(arg depth_registered)/image_raw"            unless="$(arg throttle_l515_points)" />
+        <remap from="depth_registered/points"     to="$(arg depth_registered_pub)/points" />
+      </node>
     </group>
-    <!-- Publish registered XYZRGB point cloud with hardware registered input (ROS Realsense depth alignment) -->
-    <!-- The output topic name is always /l515_head/depth_registered/points regardless of throttle option -->
-    <node pkg="nodelet" type="nodelet" name="points_xyzrgb_hw_registered"
-          args="load depth_image_proc/point_cloud_xyzrgb /l515_head/$(arg manager)" respawn="$(arg respawn)">
-      <remap from="rgb/image_rect_color"        to="$(arg rgb)/throttled/image_rect_color"        if="$(arg throttle_l515_points)" />
-      <remap from="rgb/image_rect_color"        to="$(arg rgb)/image_rect_color"                  unless="$(arg throttle_l515_points)" />
-      <remap from="rgb/camera_info"             to="$(arg rgb)/throttled/camera_info"             if="$(arg throttle_l515_points)" />
-      <remap from="rgb/camera_info"             to="$(arg rgb)/camera_info"                       unless="$(arg throttle_l515_points)" />
-      <remap from="depth_registered/image_rect" to="$(arg depth_registered)/throttled/image_raw"  if="$(arg throttle_l515_points)" />
-      <remap from="depth_registered/image_rect" to="$(arg depth_registered)/image_raw"            unless="$(arg throttle_l515_points)" />
-      <remap from="depth_registered/points"     to="$(arg depth_registered_pub)/points" />
-    </node>
   </group>
 
 </launch>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_realsense_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_realsense_bringup.launch
@@ -184,6 +184,17 @@
         <remap from="depth_registered/image_rect" to="$(arg depth_registered)/image_raw"            unless="$(arg throttle_l515_points)" />
         <remap from="depth_registered/points"     to="$(arg depth_registered_pub)/points" />
       </node>
+      <node name="resize_cloud"
+            pkg="nodelet" type="nodelet"
+            args="load jsk_pcl/ResizePointsPublisher /l515_head/$(arg manager)"
+            respawn="true">
+        <remap from="~input" to="$(arg depth_registered_pub)/points" />
+        <remap from="~output" to="$(arg depth_registered_pub)/quater/points" />
+        <rosparam>
+          step_x: 4
+          step_y: 4
+        </rosparam>
+      </node>
     </group>
   </group>
 

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_realsense_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_realsense_bringup.launch
@@ -25,6 +25,8 @@
   <arg name="rgb"                             default="color" />
   <arg name="depth_registered_pub"            default="depth_registered" />
   <arg name="depth_registered"                default="aligned_depth_to_color" />
+  <arg name="throttle_l515_points"            default="true" doc="Use throttled rgb and depth images to create pointcloud" />
+  <arg name="throttled_rate"                  default="5.0" doc="Rate [Hz] to publish L515 pointcloud" />
 
   <!-- t265 -->
   <group ns="t265" if="$(eval arg('RS_SERIAL_NO_T265') != '')">
@@ -135,12 +137,49 @@
       <arg name="rgb"                           value="$(arg rgb)" />
       <arg name="debayer_processing"            value="false" />
     </include>
+    <group if="$(arg throttle_l515_points)">
+      <group ns="$(arg rgb)">
+        <!-- Throttle RGB images -->
+        <node name="throttle_image"
+              pkg="nodelet" type="nodelet"
+              args="load jsk_topic_tools/LightweightThrottle /l515_head/$(arg manager)"
+              respawn="true">
+          <remap from="~input" to="image_rect_color" />
+          <remap from="~output" to="throttled/image_rect_color" />
+          <param name="update_rate" value="$(arg throttled_rate)" />
+        </node>
+        <!-- Throttle camera info -->
+        <node name="throttle_camera_info"
+              pkg="nodelet" type="nodelet"
+              args="load jsk_topic_tools/LightweightThrottle /l515_head/$(arg manager)"
+              respawn="true">
+          <remap from="~input" to="camera_info" />
+          <remap from="~output" to="throttled/camera_info" />
+          <param name="update_rate" value="$(arg throttled_rate)" />
+        </node>
+      </group>
+      <group ns="$(arg depth_registered)">
+        <!-- Throttle depth images -->
+        <node name="throttle_image"
+              pkg="nodelet" type="nodelet"
+              args="load jsk_topic_tools/LightweightThrottle /l515_head/$(arg manager)"
+              respawn="true">
+          <remap from="~input" to="image_raw" />
+          <remap from="~output" to="throttled/image_raw" />
+          <param name="update_rate" value="$(arg throttled_rate)" />
+        </node>
+      </group>
+    </group>
     <!-- Publish registered XYZRGB point cloud with hardware registered input (ROS Realsense depth alignment) -->
+    <!-- The output topic name is always /l515_head/depth_registered/points regardless of throttle option -->
     <node pkg="nodelet" type="nodelet" name="points_xyzrgb_hw_registered"
           args="load depth_image_proc/point_cloud_xyzrgb /l515_head/$(arg manager)" respawn="$(arg respawn)">
-      <remap from="rgb/image_rect_color"        to="$(arg rgb)/image_rect_color"        />
-      <remap from="rgb/camera_info"             to="$(arg rgb)/camera_info"             />
-      <remap from="depth_registered/image_rect" to="$(arg depth_registered)/image_raw"  />
+      <remap from="rgb/image_rect_color"        to="$(arg rgb)/throttled/image_rect_color"        if="$(arg throttle_l515_points)" />
+      <remap from="rgb/image_rect_color"        to="$(arg rgb)/image_rect_color"                  unless="$(arg throttle_l515_points)" />
+      <remap from="rgb/camera_info"             to="$(arg rgb)/throttled/camera_info"             if="$(arg throttle_l515_points)" />
+      <remap from="rgb/camera_info"             to="$(arg rgb)/camera_info"                       unless="$(arg throttle_l515_points)" />
+      <remap from="depth_registered/image_rect" to="$(arg depth_registered)/throttled/image_raw"  if="$(arg throttle_l515_points)" />
+      <remap from="depth_registered/image_rect" to="$(arg depth_registered)/image_raw"            unless="$(arg throttle_l515_points)" />
       <remap from="depth_registered/points"     to="$(arg depth_registered_pub)/points" />
     </node>
   </group>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_realsense_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_realsense_bringup.launch
@@ -122,9 +122,9 @@
       <arg name="respawn"              value="$(arg respawn)"/>
     </include>
     <rosparam>
-        /l515_head/motion_module/global_time_enabled: true
-        /l515_head/l500_depth_sensor/global_time_enabled: true
-        /l515_head/rgb_camera/global_time_enabled: true
+      /l515_head/motion_module/global_time_enabled: true
+      /l515_head/l500_depth_sensor/global_time_enabled: true
+      /l515_head/rgb_camera/global_time_enabled: true
     </rosparam>
     <!-- Create pointcloud with throttled RGB and depth image to reduce CPU usage -->
     <!--


### PR DESCRIPTION
With this PR, fetch creates L515 pointcloud from throttled rgb and depth images.
This reduces CPU usage compared to create L515 pointcloud from not-throttled rgb and depth images.

Before: CPU usage 200% with 10~15Hz pointcloud 
After: CPU usage 120% with 5Hz pointcloud

@iory
In order to further reduce CPU usage, I have tried to create L515 pointcloud from resized rgb and depth images.
However, the following cases have almost the same CPU usage, so I decided not to create resized rgb and depth images.
- resize rgb + resize depth + create pointcloud from resized rgb and depth images
- create pointcloud from not-resized rgb and depth images + resize pointcloud
