### PR TITLE
[fetcheus] update args

### DIFF
--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -13,7 +13,7 @@
   )
 
 (defmethod fetch-interface
-  (:init (&key (default-collision-object t) &rest args)
+  (:init (&rest args &key (default-collision-object t) &allow-other-keys)
    (prog1 (send-super* :init :robot fetch-robot :base-frame-id "base_link" :odom-topic "/odom_combined" :base-controller-action-name nil args)
      (send self :add-controller :arm-controller)
      (send self :add-controller :torso-controller)


### PR DESCRIPTION
This PR enables to give other key args to constructor of `fetch-interface`, and with this feature, we can give arguments for superclass like `:move_base_action_name`.

For example, if there are another move_base node with different configuration than ordinal one and it has an action interface whose name is `/move_base_no_recovery/`. We can specify the name when constructing robot interface by

```bash
(setq *ri* (instance fetch-interface :init :move-base-action-name "move_base_no_recovery"))
```