### PR TITLE
[jsk_fetch_startup] Enable shutdown_unchecked topic to shutdown when battery is not charging

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -150,7 +150,7 @@ plugins:
     type: app_publisher/rostopic_publisher_plugin
     plugin_args:
       stop_topics:
-        - name: "/shutdown"
+        - name: "/shutdown_unchecked"
           pkg: std_msgs
           type: Empty
           cond:

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -53,6 +53,9 @@
     </rosparam>
   </node>
 
+  <include file="$(find jsk_fetch_startup)/launch/fetch_shutdown.launch" >
+  </include>
+
   <node pkg="jsk_robot_startup" name="nav_speak" type="nav_speak.py" respawn="true" if="$(arg nav_speak)">
     <rosparam>
       lang: japanese

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_shutdown.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_shutdown.launch
@@ -1,0 +1,24 @@
+<launch>
+
+  <arg name="shutdown_topic" default="/shutdown" />
+  <arg name="shutdown_unchecked_topic" default="/shutdown_unchecked" />
+  <arg name="shutdown_dummy_topic" default="/shutdown_dummy" doc="Dummy input (no signal)." />
+  <arg name="battery_state_topic" default="/battery_state" />
+
+  <node name="input_shutdown_mux"
+        pkg="topic_tools" type="mux"
+        respawn="true" clear_params="true"
+	      args="$(arg shutdown_topic) $(arg shutdown_unchecked_topic) $(arg shutdown_dummy_topic)" >
+    <remap from="mux" to="input_shutdown_mux" />
+  </node>
+
+  <node name="input_shutdown_selector"
+        pkg="jsk_robot_startup" type="mux_selector.py"
+	      respawn="true"
+	      args="$(arg battery_state_topic) 'm.is_charging is True' $(arg shutdown_dummy_topic)
+              $(arg battery_state_topic) 'm.is_charging is False' $(arg shutdown_unchecked_topic)" >
+    <remap from="mux" to="input_shutdown_mux" />
+    <param name="wait" value="true" />
+  </node>
+
+</launch>


### PR DESCRIPTION
# What is this?

> This PR prevents shutdown if the robot is manually docked after kitchen demo has failed.

This is another solution of https://github.com/knorth55/jsk_robot/pull/314
