### PR TITLE
[jsk_pr2_startup] Disable warning by tweet_client_warning.l. Leave this role to audible_warning.

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_lifelog/db_client.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_lifelog/db_client.launch
@@ -3,6 +3,10 @@
   <arg name="map_frame" default="eng2" />
   <arg name="visualize_log" default="false" />
   <arg name="twitter" default="true" />
+  <arg name="worktime_enable" default="true"/>
+  <arg name="uptime_enable" default="true"/>
+  <arg name="tablet_enable" default="true"/>
+  <arg name="warning_enable" default="true"/>
   <arg name="machine" default="c2" />
   <arg name="output" default="screen" />
 
@@ -55,7 +59,12 @@
 
   <!-- tweeting robot warning data and etc. -->
   <include file="$(find jsk_pr2_startup)/jsk_pr2_lifelog/pr2_tweet.launch"
-           if="$(arg twitter)"/>
+           if="$(arg twitter)">
+    <arg name="worktime_enable" value="$(arg worktime_enable)"/>
+    <arg name="uptime_enable" value="$(arg uptime_enable)"/>
+    <arg name="tablet_enable" value="$(arg tablet_enable)"/>
+    <arg name="warning_enable" value="$(arg warning_enable)"/>
+  </include>
 
   <!-- visualization of database -->
   <include file="$(find jsk_pr2_startup)/jsk_pr2_lifelog/visualization/pr2_log_visualization.launch"

--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_lifelog/pr2_tweet.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_lifelog/pr2_tweet.launch
@@ -1,8 +1,17 @@
 <launch>
+  <arg name="worktime_enable" default="true"/>
+  <arg name="uptime_enable" default="true"/>
+  <arg name="tablet_enable" default="true"/>
+  <arg name="warning_enable" default="true"/>
+
   <include file="$(find pr2_machine)/$(env ROBOT).machine" />
 
   <include file="$(find jsk_robot_startup)/lifelog/tweet.launch">
     <arg name="robot_name" value="PR2"/>
+    <arg name="worktime_enable" value="$(arg worktime_enable)"/>
+    <arg name="uptime_enable" value="$(arg uptime_enable)"/>
+    <arg name="tablet_enable" value="$(arg tablet_enable)"/>
+    <arg name="warning_enable" value="$(arg warning_enable)"/>
     <arg name="image_topics" default="/edgetpu_human_pose_estimator/output/image" />
 
     <arg name="machine" value="c2"/>

--- a/jsk_pr2_robot/jsk_pr2_startup/pr2.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/pr2.launch
@@ -77,6 +77,7 @@
     <arg name="map_frame" value="$(arg map_frame)" />
     <arg name="twitter" value="$(arg launch_twitter)"/>
     <arg name="visualize_log" value="$(arg launch_visualize_log)"/>
+    <arg name="warning_enable" value="false" />  <!-- disable warning by tweet_client_warning.l. Leave this role to audible_warning. -->
   </include>
 
   <!-- look at human for PR2 -->


### PR DESCRIPTION
こちらのissueに関連するPRです　
https://github.com/jsk-ros-pkg/jsk_robot/issues/1562
`waarning_enable`に`false`を渡して、warningに関してaudible warningの出力のみをtweetするようにしました。
