### PR TITLE
[jsk_fetch_startup] Supervisor save the log-wifi-link.sh log

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/log-wifi-link.sh
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/log-wifi-link.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 IFACE=wlan0
-OUTPATH=/var/log/wifi.log
 INTERVAL=10
 
 wifi_status(){
@@ -13,11 +12,6 @@ wifi_status(){
     local bitrate=$(iw $IFACE link | grep bitrate | cut -d':' -f2)
     echo "$(date -Iseconds),$ssid,$freq,$signal,$level,$noise,$bitrate"
 }
-
-OUTDIR=$(dirname $OUTPATH)
-if [ ! -d $OUTDIR ]; then
-    mkdir -p $OUTDIR
-fi
 
 print_help(){
     echo "Usage: $0 [-i INTERVAL (default: 10)] [-I IFACE (default: wlan0)]"
@@ -34,6 +28,6 @@ do
 done
 
 while true; do
-    wifi_status >> $OUTPATH
+    wifi_status
     sleep $INTERVAL
 done


### PR DESCRIPTION
Currently, `/var/log` is write-protected, so `OUTPATH=/var/log/wifi.log` is unavailable.

I think supervisor should save the log, not each monitoring script (e.g. log-wifi-link.sh)
The directory where the log is saved often changes when init daemon is changed.