### PR TITLE
Disable shutdown_unchecked and enable ~input_condition for shutdown

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -150,7 +150,7 @@ plugins:
     type: app_publisher/rostopic_publisher_plugin
     plugin_args:
       stop_topics:
-        - name: "/shutdown_unchecked"
+        - name: "/shutdown"
           pkg: std_msgs
           type: Empty
           cond:

--- a/jsk_robot_common/jsk_robot_startup/README.md
+++ b/jsk_robot_common/jsk_robot_startup/README.md
@@ -181,19 +181,19 @@ This node shuts down or reboots the robot itself according to the rostopic. Note
 
 * `shutdown` (`std_msgs/Empty`)
 
-  Input topic that trigger shutdown
+  Input topic that trigger shutdown.
+
+  If `~input_condition` is set, evaluated `~input_condition` is `True` and this node received this topic, shutdown will be executed.
+
+  Even if you want to force shutdown, set `~input_condition` to `None` and send `shutdown` topic.
 
 * `reboot` (`std_msgs/Empty`)
 
   Input topic that trigger reboot
 
-* `shutdown_unchecked` (`std_msgs/Empty`)
-
-  Input topic that trigger shutdown. This is valid only when `~input_condition` param is set. If evaluated `~input_condition` is `True` and the node received this topic, shutdown will be executed.
-
 * `~input` (`AnyMsg`)
 
-  Input value for `shutdown_unchecked`.
+  Input ros message for `~input_condition`.
 
 
 ### Parameters

--- a/jsk_robot_common/jsk_robot_startup/scripts/shutdown.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/shutdown.py
@@ -35,20 +35,17 @@ class Shutdown(object):
     def __init__(self):
         rospy.loginfo('Start shutdown node.')
         self.client_jp = SoundClient(sound_action='/robotsound_jp', blocking=True)
-        condition = rospy.get_param(
+        self.condition = rospy.get_param(
             '~input_condition', None)
-        if condition is not None:
-            self.condition = condition
+        if self.condition is not None:
             self.topic_name = rospy.resolve_name('~input')
-            self.filter_fn = expr_eval(condition)
+            self.filter_fn = expr_eval(self.condition)
             self.last_received_topic = None
             self.sub_check_topic = rospy.Subscriber(
                 self.topic_name,
                 rospy.AnyMsg,
                 callback=self.callback,
                 queue_size=1)
-            self.sub_shutdown_unchecked = rospy.Subscriber(
-                'shutdown_unchecked', Empty, self.shutdown_unchecked)
 
         rospy.Subscriber('shutdown', Empty, self.shutdown)
         rospy.Subscriber('reboot', Empty, self.reboot)
@@ -75,22 +72,27 @@ class Shutdown(object):
         self.last_received_topic = self.topic_name, msg, rospy.Time.now()
 
     def shutdown(self, msg):
+        if self.condition is not None:
+            if self.last_received_topic is None:
+                rospy.loginfo(
+                    'received shutdown. '
+                    'However input topic "{}" has not been received.'
+                    .format(self.topic_name))
+                return
+            topic_name, m, t = self.last_received_topic
+            if self.filter_fn(topic_name, m, t) is False:
+                rospy.loginfo(
+                    'received shutdown. '
+                    'However condition "{}" is not satisfied.'
+                    .format(self.condition))
+                return
+
         rospy.loginfo('Shut down robot.')
         self.speak(self.client_jp, 'シャットダウンします。')
         ret = os.system(self.shutdown_command)
         if ret != 0:
             rospy.logerr("Failed to call '$ {}'. Check authentication.".format(
                 self.shutdown_command))
-
-    def shutdown_unchecked(self, msg):
-        if self.last_received_topic is None:
-            return
-        topic_name, m, t = self.last_received_topic
-        if self.filter_fn(topic_name, m, t):
-            self.shutdown(msg)
-        else:
-            rospy.loginfo('received shutdown_unchecked. However condition {} is not satisfied.'
-                          .format(self.condition))
 
     def reboot(self, msg):
         rospy.loginfo('Reboot robot.')


### PR DESCRIPTION
# What is this?

If `~input_condition` is set, evaluated `~input_condition` is `True` and this node received this topic, shutdown will be executed.
Even if you want to force shutdown, set `~input_condition` to `None` and send `shutdown` topic.

Upstream: https://github.com/jsk-ros-pkg/jsk_robot/pull/1571
